### PR TITLE
Feature/add linkAnimConfig system for animated link status transitions

### DIFF
--- a/frontend/src/data/DataStructure/nonlinear/BinarySearchTree/BinarySearchTree.tsx
+++ b/frontend/src/data/DataStructure/nonlinear/BinarySearchTree/BinarySearchTree.tsx
@@ -254,7 +254,7 @@ function runInsert(inputData: any[]): AnimationStep[] {
     if (newValue === curr.value) {
       statusMap[curr.id] = Status.Complete;
       pathLinks.forEach(({ u, v }) =>
-        updateLinkStatus(linkStatusMap, u, v, "complete", true),
+        updateLinkStatus(linkStatusMap, u, v, "complete", false),
       );
       steps.push(
         generateFrame(
@@ -271,7 +271,7 @@ function runInsert(inputData: any[]): AnimationStep[] {
     if (newValue < curr.value) {
       if (curr.left) {
         statusMap[curr.left.id] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "path", true);
+        updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "prepare", true);
         pathLinks.push({ u: curr.id, v: curr.left.id });
         steps.push(
           generateFrame(
@@ -303,7 +303,7 @@ function runInsert(inputData: any[]): AnimationStep[] {
     } else {
       if (curr.right) {
         statusMap[curr.right.id] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "path", true);
+        updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "prepare", true);
         pathLinks.push({ u: curr.id, v: curr.right.id });
         steps.push(
           generateFrame(
@@ -338,9 +338,9 @@ function runInsert(inputData: any[]): AnimationStep[] {
   if (curr) {
     statusMap[curr.id] = Status.Unfinished;
     pathLinks.forEach(({ u, v }) =>
-      updateLinkStatus(linkStatusMap, u, v, "complete", true),
+      updateLinkStatus(linkStatusMap, u, v, "unfinished", false),
     );
-    updateLinkStatus(linkStatusMap, curr.id, newNodeData.id, "complete", true);
+    updateLinkStatus(linkStatusMap, curr.id, newNodeData.id, "complete", false);
   }
   steps.push(
     generateFrame(
@@ -411,7 +411,7 @@ function runSearch(inputData: any[], targetValue: number): AnimationStep[] {
     if (targetValue === curr.value) {
       statusMap[curr.id] = Status.Complete;
       searchPathLinks.forEach(({ u, v }) => {
-        updateLinkStatus(linkStatusMap, u, v, "complete", true);
+        updateLinkStatus(linkStatusMap, u, v, "complete", false);
       });
       steps.push(
         generateFrame(
@@ -428,7 +428,7 @@ function runSearch(inputData: any[], targetValue: number): AnimationStep[] {
     } else if (targetValue < curr.value) {
       if (curr.left) {
         statusMap[curr.left.id] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "path", true);
+        updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "prepare", true);
         searchPathLinks.push({ u: curr.id, v: curr.left.id });
         steps.push(
           generateFrame(
@@ -460,7 +460,7 @@ function runSearch(inputData: any[], targetValue: number): AnimationStep[] {
     } else {
       if (curr.right) {
         statusMap[curr.right.id] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "path", true);
+        updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "prepare", true);
         searchPathLinks.push({ u: curr.id, v: curr.right.id });
         steps.push(
           generateFrame(
@@ -491,7 +491,10 @@ function runSearch(inputData: any[], targetValue: number): AnimationStep[] {
       }
     }
   }
-  if (!found)
+  if (!found) {
+    searchPathLinks.forEach(({ u, v }) => {
+      updateLinkStatus(linkStatusMap, u, v, "unfinished", false);
+    });
     steps.push(
       generateFrame(
         inputData,
@@ -502,6 +505,7 @@ function runSearch(inputData: any[], targetValue: number): AnimationStep[] {
         { ...linkStatusMap },
       ),
     );
+  }
   return steps;
 }
 
@@ -570,7 +574,7 @@ function runDelete(inputData: any[], targetValue: number): AnimationStep[] {
       foundNode = curr;
       statusMap[curr.id] = Status.Complete;
       pathLinks.forEach(({ u, v }) =>
-        updateLinkStatus(linkStatusMap, u, v, "complete", true),
+        updateLinkStatus(linkStatusMap, u, v, "complete", false),
       );
       steps.push(
         generateFrame(
@@ -588,7 +592,7 @@ function runDelete(inputData: any[], targetValue: number): AnimationStep[] {
     if (targetValue < curr.value) {
       if (curr.left) {
         statusMap[curr.left.id] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "path", true);
+        updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "prepare", true);
         pathLinks.push({ u: curr.id, v: curr.left.id });
         steps.push(
           generateFrame(
@@ -620,7 +624,7 @@ function runDelete(inputData: any[], targetValue: number): AnimationStep[] {
     } else {
       if (curr.right) {
         statusMap[curr.right.id] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "path", true);
+        updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "prepare", true);
         pathLinks.push({ u: curr.id, v: curr.right.id });
         steps.push(
           generateFrame(
@@ -654,7 +658,7 @@ function runDelete(inputData: any[], targetValue: number): AnimationStep[] {
 
   if (!foundNode) {
     pathLinks.forEach(({ u, v }) =>
-      updateLinkStatus(linkStatusMap, u, v, "path", true),
+      updateLinkStatus(linkStatusMap, u, v, "unfinished", false),
     );
 
     steps.push(
@@ -736,7 +740,7 @@ function runDelete(inputData: any[], targetValue: number): AnimationStep[] {
       return d;
     });
 
-    updateLinkStatus(linkStatusMap, targetId, child!.id, "visited", true);
+    updateLinkStatus(linkStatusMap, targetId, child!.id, "target", false);
 
     steps.push(
       generateFrame(
@@ -776,7 +780,7 @@ function runDelete(inputData: any[], targetValue: number): AnimationStep[] {
     let successor = foundNode.right;
 
     statusMap[successor!.id] = Status.Prepare;
-    updateLinkStatus(linkStatusMap, foundNode.id, successor!.id, "path", true);
+    updateLinkStatus(linkStatusMap, foundNode.id, successor!.id, "prepare", true);
     successorPathLinks.push({ u: foundNode.id, v: successor!.id });
     steps.push(
       generateFrame(
@@ -796,7 +800,7 @@ function runDelete(inputData: any[], targetValue: number): AnimationStep[] {
         linkStatusMap,
         successor!.id,
         successor!.left.id,
-        "path",
+        "prepare",
         true,
       );
       successorPathLinks.push({ u: successor!.id, v: successor!.left.id });
@@ -816,7 +820,7 @@ function runDelete(inputData: any[], targetValue: number): AnimationStep[] {
 
     statusMap[successor!.id] = Status.Complete;
     successorPathLinks.forEach(({ u, v }) =>
-      updateLinkStatus(linkStatusMap, u, v, "complete", true),
+      updateLinkStatus(linkStatusMap, u, v, "complete", false),
     );
     steps.push(
       generateFrame(
@@ -851,10 +855,14 @@ function runDelete(inputData: any[], targetValue: number): AnimationStep[] {
     );
 
     const finalData = getBSTArrayAfterDelete(inputData, targetValue);
+    const finalStatusMap: Record<string, Status> = {
+      [targetId]: Status.Complete,
+    };
+
     steps.push(
       generateFrame(
         finalData,
-        {},
+        finalStatusMap,
         `移除原本的後繼者節點 ${successor!.value}，重組結構，刪除完成`,
         TAGS.DEL_SUCCESSOR_REMOVE,
         getVars(),
@@ -903,7 +911,7 @@ function runMin(inputData: any[]): AnimationStep[] {
       ),
     );
     statusMap[curr.left.id] = Status.Prepare;
-    updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "path", true);
+    updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "prepare", true);
     pathLinks.push({ u: curr.id, v: curr.left.id });
     steps.push(
       generateFrame(
@@ -921,7 +929,7 @@ function runMin(inputData: any[]): AnimationStep[] {
   }
   statusMap[curr.id] = Status.Complete;
   pathLinks.forEach(({ u, v }) => {
-    updateLinkStatus(linkStatusMap, u, v, "complete", true);
+    updateLinkStatus(linkStatusMap, u, v, "unfinished", false);
   });
   steps.push(
     generateFrame(
@@ -973,7 +981,7 @@ function runMax(inputData: any[]): AnimationStep[] {
       ),
     );
     statusMap[curr.right.id] = Status.Prepare;
-    updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "path", true);
+    updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "prepare", true);
     pathLinks.push({ u: curr.id, v: curr.right.id });
     steps.push(
       generateFrame(
@@ -991,7 +999,7 @@ function runMax(inputData: any[]): AnimationStep[] {
   }
   statusMap[curr.id] = Status.Complete;
   pathLinks.forEach(({ u, v }) => {
-    updateLinkStatus(linkStatusMap, u, v, "complete", true);
+    updateLinkStatus(linkStatusMap, u, v, "unfinished", false);
   });
   steps.push(
     generateFrame(
@@ -1051,7 +1059,7 @@ function runFloor(inputData: any[], targetValue: number): AnimationStep[] {
       if (floorNode) statusMap[floorNode.id] = Status.Unfinished;
       statusMap[curr.id] = Status.Complete;
       pathLinks.forEach(({ u, v }) =>
-        updateLinkStatus(linkStatusMap, u, v, "complete", true),
+        updateLinkStatus(linkStatusMap, u, v, "complete", false),
       );
       steps.push(
         generateFrame(
@@ -1069,7 +1077,7 @@ function runFloor(inputData: any[], targetValue: number): AnimationStep[] {
     if (curr.value > targetValue) {
       if (curr.left) {
         statusMap[curr.left.id] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "path", true);
+        updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "prepare", true);
         pathLinks.push({ u: curr.id, v: curr.left.id });
         steps.push(
           generateFrame(
@@ -1102,7 +1110,7 @@ function runFloor(inputData: any[], targetValue: number): AnimationStep[] {
       statusMap[curr.id] = Status.Complete;
       if (curr.right) {
         statusMap[curr.right.id] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "path", true);
+        updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "prepare", true);
         pathLinks.push({ u: curr.id, v: curr.right.id });
         steps.push(
           generateFrame(
@@ -1133,7 +1141,7 @@ function runFloor(inputData: any[], targetValue: number): AnimationStep[] {
   }
   if (floorNode) {
     pathLinks.forEach(({ u, v }) =>
-      updateLinkStatus(linkStatusMap, u, v, "complete", true),
+      updateLinkStatus(linkStatusMap, u, v, "unfinished", false),
     );
     steps.push(
       generateFrame(
@@ -1147,7 +1155,7 @@ function runFloor(inputData: any[], targetValue: number): AnimationStep[] {
     );
   } else {
     pathLinks.forEach(({ u, v }) =>
-      updateLinkStatus(linkStatusMap, u, v, "visited", true),
+      updateLinkStatus(linkStatusMap, u, v, Status.Unfinished as linkStatus, false),
     );
     steps.push(
       generateFrame(
@@ -1206,7 +1214,7 @@ function runCeil(inputData: any[], targetValue: number): AnimationStep[] {
       if (ceilNode) statusMap[ceilNode.id] = Status.Unfinished;
       statusMap[curr.id] = Status.Complete;
       pathLinks.forEach(({ u, v }) =>
-        updateLinkStatus(linkStatusMap, u, v, "complete", true),
+        updateLinkStatus(linkStatusMap, u, v, "complete", false),
       );
       steps.push(
         generateFrame(
@@ -1223,7 +1231,7 @@ function runCeil(inputData: any[], targetValue: number): AnimationStep[] {
     if (curr.value < targetValue) {
       if (curr.right) {
         statusMap[curr.right.id] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "path", true);
+        updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "prepare", true);
         pathLinks.push({ u: curr.id, v: curr.right.id });
         steps.push(
           generateFrame(
@@ -1256,7 +1264,7 @@ function runCeil(inputData: any[], targetValue: number): AnimationStep[] {
       statusMap[curr.id] = Status.Complete;
       if (curr.left) {
         statusMap[curr.left.id] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "path", true);
+        updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "prepare", true);
         pathLinks.push({ u: curr.id, v: curr.left.id });
         steps.push(
           generateFrame(
@@ -1287,7 +1295,7 @@ function runCeil(inputData: any[], targetValue: number): AnimationStep[] {
   }
   if (ceilNode) {
     pathLinks.forEach(({ u, v }) =>
-      updateLinkStatus(linkStatusMap, u, v, "complete", true),
+      updateLinkStatus(linkStatusMap, u, v, "unfinished", false),
     );
     steps.push(
       generateFrame(
@@ -1301,7 +1309,7 @@ function runCeil(inputData: any[], targetValue: number): AnimationStep[] {
     );
   } else {
     pathLinks.forEach(({ u, v }) =>
-      updateLinkStatus(linkStatusMap, u, v, "visited", true),
+      updateLinkStatus(linkStatusMap, u, v, Status.Unfinished as linkStatus, false),
     );
     steps.push(
       generateFrame(
@@ -1748,6 +1756,10 @@ def ceil(root, target):
 export const BinarySearchTreeConfig: LevelImplementationConfig = {
   id: "bst",
   type: "dataStructure",
+  linkAnimConfig: {
+    animateOn: ["prepare"],
+    directOn: ["target", "complete"],
+  },
   name: "二元搜尋樹 (BST)",
   categoryName: "資料結構",
   description:

--- a/frontend/src/data/DataStructure/nonlinear/BinaryTree/BinaryTree.tsx
+++ b/frontend/src/data/DataStructure/nonlinear/BinaryTree/BinaryTree.tsx
@@ -229,7 +229,7 @@ function runPreorder(inputData: any[]): AnimationStep[] {
 
     if (node.left) {
       statusMap[node.left.id] = Status.Prepare;
-      updateLinkStatus(linkStatusMap, node.id, node.left.id, "path", true);
+      updateLinkStatus(linkStatusMap, node.id, node.left.id, "prepare", true);
       steps.push(
         generateFrame(
           inputData,
@@ -245,7 +245,7 @@ function runPreorder(inputData: any[]): AnimationStep[] {
       );
       delete statusMap[node.left.id];
       traverse(node.left);
-      updateLinkStatus(linkStatusMap, node.id, node.left.id, "visited", true);
+      updateLinkStatus(linkStatusMap, node.id, node.left.id, "complete", true);
 
       const originalStatus = statusMap[node.id];
       statusMap[node.id] = Status.Target;
@@ -310,7 +310,7 @@ function runPreorder(inputData: any[]): AnimationStep[] {
 
     if (node.right) {
       statusMap[node.right.id] = Status.Prepare;
-      updateLinkStatus(linkStatusMap, node.id, node.right.id, "path", true);
+      updateLinkStatus(linkStatusMap, node.id, node.right.id, "prepare", true);
       steps.push(
         generateFrame(
           inputData,
@@ -328,7 +328,7 @@ function runPreorder(inputData: any[]): AnimationStep[] {
 
       traverse(node.right);
 
-      updateLinkStatus(linkStatusMap, node.id, node.right.id, "visited", true);
+      updateLinkStatus(linkStatusMap, node.id, node.right.id, "complete", true);
       const originalStatus = statusMap[node.id];
       statusMap[node.id] = Status.Target;
       steps.push(
@@ -481,7 +481,7 @@ function runInorder(inputData: any[]): AnimationStep[] {
 
     if (node.left) {
       statusMap[node.left.id] = Status.Prepare;
-      updateLinkStatus(linkStatusMap, node.id, node.left.id, "path", true);
+      updateLinkStatus(linkStatusMap, node.id, node.left.id, "prepare", true);
       steps.push(
         generateFrame(
           inputData,
@@ -499,7 +499,7 @@ function runInorder(inputData: any[]): AnimationStep[] {
 
       traverse(node.left);
 
-      updateLinkStatus(linkStatusMap, node.id, node.left.id, "visited", true);
+      updateLinkStatus(linkStatusMap, node.id, node.left.id, "complete", true);
 
       const originalStatus = statusMap[node.id];
       statusMap[node.id] = Status.Target;
@@ -580,7 +580,7 @@ function runInorder(inputData: any[]): AnimationStep[] {
 
     if (node.right) {
       statusMap[node.right.id] = Status.Prepare;
-      updateLinkStatus(linkStatusMap, node.id, node.right.id, "path", true);
+      updateLinkStatus(linkStatusMap, node.id, node.right.id, "prepare", true);
       steps.push(
         generateFrame(
           inputData,
@@ -598,7 +598,7 @@ function runInorder(inputData: any[]): AnimationStep[] {
 
       traverse(node.right);
 
-      updateLinkStatus(linkStatusMap, node.id, node.right.id, "visited", true);
+      updateLinkStatus(linkStatusMap, node.id, node.right.id, "complete", true);
 
       const originalStatus = statusMap[node.id];
       statusMap[node.id] = Status.Target;
@@ -752,7 +752,7 @@ function runPostorder(inputData: any[]): AnimationStep[] {
 
     if (node.left) {
       statusMap[node.left.id] = Status.Prepare;
-      updateLinkStatus(linkStatusMap, node.id, node.left.id, "path", true);
+      updateLinkStatus(linkStatusMap, node.id, node.left.id, "prepare", true);
       steps.push(
         generateFrame(
           inputData,
@@ -770,7 +770,7 @@ function runPostorder(inputData: any[]): AnimationStep[] {
 
       traverse(node.left);
 
-      updateLinkStatus(linkStatusMap, node.id, node.left.id, "visited", true);
+      updateLinkStatus(linkStatusMap, node.id, node.left.id, "complete", true);
       statusMap[node.id] = Status.Target;
       steps.push(
         generateFrame(
@@ -831,7 +831,7 @@ function runPostorder(inputData: any[]): AnimationStep[] {
 
     if (node.right) {
       statusMap[node.right.id] = Status.Prepare;
-      updateLinkStatus(linkStatusMap, node.id, node.right.id, "path", true);
+      updateLinkStatus(linkStatusMap, node.id, node.right.id, "prepare", true);
       steps.push(
         generateFrame(
           inputData,
@@ -849,7 +849,7 @@ function runPostorder(inputData: any[]): AnimationStep[] {
 
       traverse(node.right);
 
-      updateLinkStatus(linkStatusMap, node.id, node.right.id, "visited", true);
+      updateLinkStatus(linkStatusMap, node.id, node.right.id, "complete", true);
       statusMap[node.id] = Status.Target;
       steps.push(
         generateFrame(
@@ -1007,7 +1007,7 @@ function runBFS(inputData: any[]): AnimationStep[] {
     const { node: curr, parent } = queue[0];
 
     if (parent) {
-      updateLinkStatus(linkStatusMap, parent.id, curr.id, "visited", true);
+      updateLinkStatus(linkStatusMap, parent.id, curr.id, "complete", true);
     }
 
     statusMap[curr.id] = Status.Target;
@@ -1044,7 +1044,7 @@ function runBFS(inputData: any[]): AnimationStep[] {
 
     if (curr.left) {
       statusMap[curr.left.id] = Status.Prepare;
-      updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "path", true);
+      updateLinkStatus(linkStatusMap, curr.id, curr.left.id, "prepare", true);
       steps.push(
         generateFrame(
           inputData,
@@ -1078,7 +1078,7 @@ function runBFS(inputData: any[]): AnimationStep[] {
 
     if (curr.right) {
       statusMap[curr.right.id] = Status.Prepare;
-      updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "path", true);
+      updateLinkStatus(linkStatusMap, curr.id, curr.right.id, "prepare", true);
       steps.push(
         generateFrame(
           inputData,
@@ -1317,6 +1317,10 @@ export const BinaryTreeConfig: LevelImplementationConfig = {
     { id: "node-6", value: 6 },
     { id: "node-7", value: 7 },
   ],
+  linkAnimConfig: {
+    animateOn: ["prepare"],
+    directOn: ["complete"],
+  },
   createAnimationSteps: createBinaryTreeAnimationSteps,
   actionHandler: binaryTreeActionHandler,
   renderActionBar: (props) => <BinaryTreeActionBar {...(props as any)} />,

--- a/frontend/src/data/DataStructure/nonlinear/Graph/Graph.tsx
+++ b/frontend/src/data/DataStructure/nonlinear/Graph/Graph.tsx
@@ -421,8 +421,8 @@ function runGetNeighbors(
           linkStatusMap,
           targetId,
           neighbor.id,
-          "path",
-          isDirected,
+          "prepare",
+          true,
         );
         steps.push({
           ...generateGraphFrame(
@@ -610,8 +610,8 @@ function runGetDegree(
             linkStatusMap,
             otherNode.id,
             targetId,
-            "path",
-            isDirected,
+            "prepare",
+            true,
           );
           inDegree++;
         }
@@ -629,8 +629,8 @@ function runGetDegree(
           linkStatusMap,
           targetId,
           neighbor.id,
-          "path",
-          isDirected,
+          "prepare",
+          true,
         );
       });
 
@@ -724,6 +724,19 @@ function runCheckConnected(
     const currId = queue.shift()!;
 
     statusMap[currId] = Status.Target;
+    // 先推一個 Frame，顯示當前正在處理的節點 (Target)
+    steps.push({
+      ...generateGraphFrame(
+        baseElements,
+        { ...statusMap },
+        {},
+        `正在處理節點 ${currId.replace("node-", "")}，尋找未訪問的鄰居`,
+        true,
+        { ...linkStatusMap },
+      ),
+      actionTag: TAGS.CHECK_CONNECTED_WHILE,
+      variables: { current: currId, queue: queue.join(", ") },
+    });
 
     const neighbors = undirectedAdj.get(currId) || [];
 
@@ -736,16 +749,9 @@ function runCheckConnected(
         newFound = true;
         updateLinkStatus(
           linkStatusMap,
-          currId,
-          neighborId,
-          Status.Complete,
-          isDirected,
-        );
-        updateLinkStatus(
-          linkStatusMap,
           neighborId,
           currId,
-          Status.Complete,
+          Status.Prepare,
           isDirected,
         );
       }
@@ -767,6 +773,32 @@ function runCheckConnected(
       });
     }
     statusMap[currId] = Status.Complete;
+    // 當節點變為 Complete (綠色) 時，將與其相連且已訪問的邊也設為 Complete
+    neighbors.forEach((neighborId) => {
+      if (visited.has(neighborId) && statusMap[neighborId] === Status.Complete) {
+        updateLinkStatus(
+          linkStatusMap,
+          currId,
+          neighborId,
+          Status.Complete,
+          isDirected,
+        );
+      }
+    });
+
+    // 推一個 Frame 顯示當前節點變綠且連線變綠的狀態
+    steps.push({
+      ...generateGraphFrame(
+        baseElements,
+        { ...statusMap },
+        {},
+        `節點 ${currId.replace("node-", "")} 處理完成，已訪問 ${visited.size} / ${baseElements.length} 個節點`,
+        true,
+        { ...linkStatusMap },
+      ),
+      actionTag: TAGS.CHECK_CONNECTED_WHILE,
+      variables: { current: currId, queue: queue.join(", ") },
+    });
   }
 
   // Frame Final: 結果判定
@@ -840,10 +872,6 @@ function runCheckCycle(graphData: any, isDirected: boolean): AnimationStep[] {
       actionTag: TAGS.CHECK_CYCLE_DFS,
       variables: { current: currId },
     });
-    if (parentId !== null) {
-      updateLinkStatus(linkStatusMap, parentId, currId, "path", isDirected);
-    }
-    statusMap[currId] = Status.Prepare;
 
     const currNode = baseElements.find((n) => n.id === currId);
     if (currNode) {
@@ -855,7 +883,7 @@ function runCheckCycle(graphData: any, isDirected: boolean): AnimationStep[] {
           currId,
           neighborId,
           Status.Target,
-          isDirected,
+          true,
         );
 
         if (!visited.has(neighborId)) {
@@ -866,8 +894,8 @@ function runCheckCycle(graphData: any, isDirected: boolean): AnimationStep[] {
             linkStatusMap,
             currId,
             neighborId,
-            "visited",
-            isDirected,
+            Status.Complete,
+            true,
           );
           steps.push({
             ...generateGraphFrame(
@@ -900,7 +928,7 @@ function runCheckCycle(graphData: any, isDirected: boolean): AnimationStep[] {
             for (let i = 0; i < cyclePath.length - 1; i++) {
               const u = cyclePath[i];
               const v = cyclePath[i + 1];
-              updateLinkStatus(linkStatusMap, u, v, Status.Target, isDirected);
+              updateLinkStatus(linkStatusMap, u, v, Status.Target, true);
             }
 
             cyclePath.forEach((id) => (statusMap[id] = Status.Target));
@@ -924,18 +952,10 @@ function runCheckCycle(graphData: any, isDirected: boolean): AnimationStep[] {
               linkStatusMap,
               currId,
               neighborId,
-              "visited",
-              isDirected,
+              Status.Complete,
+              true,
             );
-          } else {
-            updateLinkStatus(
-              linkStatusMap,
-              currId,
-              neighborId,
-              "path",
-              isDirected,
-            );
-          }
+          } 
         }
       }
     }
@@ -1577,6 +1597,10 @@ export const GraphConfig: LevelImplementationConfig = {
     "由節點 (Vertex) 與邊 (Edge) 組成的資料結構，用於描述物件之間的關係。",
   // TODO: 補完 Graph 的 pseudo code 與 mappings
   codeConfig: graphCodeConfig,
+  linkAnimConfig: {
+    animateOn: ["prepare","target"],
+    directOn: ["complete"],
+  },
   complexity: {
     timeBest: "O(1)", // 存取特定節點
     timeAverage: "O(V + E)", // 遍歷

--- a/frontend/src/data/DataStructure/nonlinear/Graph/Graph.tsx
+++ b/frontend/src/data/DataStructure/nonlinear/Graph/Graph.tsx
@@ -587,12 +587,12 @@ function runGetDegree(
       // 狀態設為 Status.Unfinished
       const outDegree = targetNode.pointers.length;
       targetNode.pointers.forEach((neighbor) => {
-        statusMap[neighbor.id] = Status.Unfinished;
+        statusMap[neighbor.id] = Status.Complete;
         updateLinkStatus(
           linkStatusMap,
           targetId,
           neighbor.id,
-          "visited",
+          Status.Complete,
           isDirected,
         );
       });
@@ -605,31 +605,31 @@ function runGetDegree(
         if (otherNode.pointers.some((n) => n.id === targetId)) {
           // 如果發生雙向 (A<->B) 或 自環 (A->A)，顏色會被覆蓋。
           // 這裡 Status.Prepare (In) 會覆蓋掉 Status.Unfinished (Out)
-          statusMap[otherNode.id] = Status.Prepare;
+          statusMap[otherNode.id] = Status.Unfinished;
           updateLinkStatus(
             linkStatusMap,
             otherNode.id,
             targetId,
-            "prepare",
+            Status.Unfinished,
             true,
           );
           inDegree++;
         }
       });
 
-      msg = `節點 ${nodeId}：In-Degree (入度/黃) = ${inDegree}, Out-Degree (出度/藍) = ${outDegree}`;
+      msg = `節點 ${nodeId}：In-Degree (入度/藍) = ${inDegree}, Out-Degree (出度/綠) = ${outDegree}`;
     } else {
       // 無向圖邏輯
 
       // Degree: 所有相連的都算，統一設為 Status.Prepare
       const degree = targetNode.pointers.length;
       targetNode.pointers.forEach((neighbor) => {
-        statusMap[neighbor.id] = Status.Prepare;
+        statusMap[neighbor.id] = Status.Complete;
         updateLinkStatus(
           linkStatusMap,
           targetId,
           neighbor.id,
-          "prepare",
+          Status.Complete,
           true,
         );
       });
@@ -637,7 +637,7 @@ function runGetDegree(
       msg = `節點 ${nodeId}：Degree (度數) = ${degree}`;
     }
 
-    statusMap[targetId] = Status.Complete;
+    // statusMap[targetId] = Status.Complete;
 
     steps.push({
       ...generateGraphFrame(baseElements, statusMap, {}, msg, true, {
@@ -747,14 +747,19 @@ function runCheckConnected(
         queue.push(neighborId);
         statusMap[neighborId] = Status.Prepare;
         newFound = true;
+        // undirectedAdj 不保留原始邊方向，寫兩個 key 確保命中實際存在的方向
         updateLinkStatus(
           linkStatusMap,
-          neighborId,
           currId,
+          neighborId,
           Status.Prepare,
-          isDirected,
+          false,
         );
-      }
+      } else if (statusMap[neighborId] === Status.Prepare) {
+    // Cross edge：對方已 visited 但還是 Prepare，邊也染 Prepare
+    updateLinkStatus(linkStatusMap, currId, neighborId, Status.Prepare, false);
+    newFound = true;
+  }
     });
 
     // 如果有新發現的節點，推一個 Frame 顯示擴散進度
@@ -773,15 +778,15 @@ function runCheckConnected(
       });
     }
     statusMap[currId] = Status.Complete;
-    // 當節點變為 Complete (綠色) 時，將與其相連且已訪問的邊也設為 Complete
+    // 節點變為 Complete 時，與已訪問鄰居之間的邊也立即變綠
     neighbors.forEach((neighborId) => {
-      if (visited.has(neighborId) && statusMap[neighborId] === Status.Complete) {
+      if (visited.has(neighborId)) {
         updateLinkStatus(
           linkStatusMap,
           currId,
           neighborId,
           Status.Complete,
-          isDirected,
+          false,
         );
       }
     });
@@ -805,20 +810,38 @@ function runCheckConnected(
   const isConnected = visited.size === baseElements.length;
   let resultMsg = "";
 
+  const finalStatusMap: Record<string, Status> = { ...statusMap };
+  const finalLinkStatusMap: Record<string, linkStatus> = { ...linkStatusMap };
+
   if (isConnected) {
     resultMsg = "結果：圖是連通的 (Connected)！所有節點皆可達。";
+    
   } else {
-    resultMsg = "結果：圖不連通 (Disconnected)。紅色節點為孤島。";
+    resultMsg = "結果：圖不連通 (Disconnected)。橙色節點為孤島。";
     baseElements.forEach((n) => {
       if (!visited.has(n.id)) {
-        statusMap[n.id] = Status.Target;
+        finalStatusMap[n.id] = Status.Target; // 孤島設為橙色
+      } else {
+        finalStatusMap[n.id] = Status.Unfinished; // 已訪問設為藍色
+        // 處理已訪問節點之間的邊
+        n.pointers.forEach((neighbor) => {
+          if (visited.has(neighbor.id)) {
+            updateLinkStatus(
+              finalLinkStatusMap,
+              n.id,
+              neighbor.id,
+              Status.Unfinished,
+              isDirected,
+            );
+          }
+        });
       }
     });
   }
 
   steps.push({
-    ...generateGraphFrame(baseElements, statusMap, {}, resultMsg, true, {
-      ...linkStatusMap,
+    ...generateGraphFrame(baseElements, finalStatusMap, {}, resultMsg, true, {
+      ...finalLinkStatusMap,
     }),
     actionTag: TAGS.CHECK_CONNECTED_RESULT,
     variables: { isConnected: isConnected },
@@ -997,14 +1020,35 @@ function runCheckCycle(graphData: any, isDirected: boolean): AnimationStep[] {
 
   // 最終結果
   if (!hasCycle) {
+    const finalStatusMap: Record<string, Status> = {};
+    const finalLinkStatusMap: Record<string, linkStatus> = {};
+
+    visited.forEach((id) => {
+      finalStatusMap[id] = Status.Unfinished;
+      const node = baseElements.find((n) => n.id === id);
+      if (node) {
+        node.pointers.forEach((neighbor) => {
+          if (visited.has(neighbor.id)) {
+            updateLinkStatus(
+              finalLinkStatusMap,
+              id,
+              neighbor.id,
+              Status.Unfinished,
+              isDirected,
+            );
+          }
+        });
+      }
+    });
+
     steps.push({
       ...generateGraphFrame(
         baseElements,
-        statusMap, // 全綠
+        finalStatusMap,
         {},
         "檢查結束：此圖無環 (Acyclic)。",
         true,
-        {},
+        finalLinkStatusMap,
       ),
       actionTag: TAGS.CHECK_CYCLE_END_FALSE,
       variables: { hasCycle: false },
@@ -1013,11 +1057,40 @@ function runCheckCycle(graphData: any, isDirected: boolean): AnimationStep[] {
     const finalStatusMap: Record<string, Status> = {};
 
     visited.forEach((id) => {
-      finalStatusMap[id] = Status.Complete;
+      finalStatusMap[id] = Status.Unfinished;
+      // 將與已訪問節點相連的所有邊也設為 Unfinished (藍色)
+      const node = baseElements.find((n) => n.id === id);
+      if (node) {
+        node.pointers.forEach((neighbor) => {
+          if (visited.has(neighbor.id)) {
+            updateLinkStatus(
+              linkStatusMap,
+              id,
+              neighbor.id,
+              Status.Unfinished,
+              isDirected,
+            );
+          }
+        });
+      }
     });
 
     cyclePath.forEach((id) => {
       finalStatusMap[id] = Status.Target; // 環設 target
+      const node = baseElements.find((n) => n.id === id);
+      if (node) {
+        node.pointers.forEach((neighbor) => {
+          if (visited.has(neighbor.id)) {
+            updateLinkStatus(
+              linkStatusMap,
+              id,
+              neighbor.id,
+              Status.Target,
+              isDirected,
+            );
+          }
+        });
+      }
     });
 
     // 格式化路徑字串 (例如: A -> B -> C -> A)

--- a/frontend/src/data/algorithms/searching/BFS.tsx
+++ b/frontend/src/data/algorithms/searching/BFS.tsx
@@ -253,7 +253,7 @@ function runGraphBFS(
     const currNode = nodeMap.get(currId);
     const parentId = parentMap.get(currId);
     if (parentId) {
-      updateLinkStatus(linkStatusMap, parentId, currId, "visited", false);
+      updateLinkStatus(linkStatusMap, parentId, currId, "target", false);
     }
 
     statusMap[currId] = Status.Target;
@@ -339,7 +339,7 @@ function runGraphBFS(
 
           statusMap[neighbor.id] = Status.Prepare;
           // distanceMap 在 VISIT_NEIGHBOR frame 之後才更新
-          updateLinkStatus(linkStatusMap, currId, neighbor.id, "path", false);
+          updateLinkStatus(linkStatusMap, currId, neighbor.id, "prepare", false);
         }
       }
 
@@ -386,8 +386,10 @@ function runGraphBFS(
       }
     }
 
-    // 處理完畢 -> Unfinished
     statusMap[currId] = Status.Unfinished;
+    if (parentId) {
+      updateLinkStatus(linkStatusMap, parentId, currId, Status.Unfinished as linkStatus, false);
+    }
   }
 
   // 路徑回溯與結束
@@ -887,6 +889,10 @@ BFS 的時間複雜度為 O(V + E)，其中 V 是節點數量，E 是邊數量�
   createAnimationSteps: createBFSAnimationSteps,
   actionHandler: bfsActionHandler,
   defaultViewMode: "graph",
+  linkAnimConfig: {
+    animateOn: ["prepare"],
+    directOn: ["target", "complete"],
+  },
   renderActionBar: (props) => <BFSDFSActionBar {...(props as any)} />,
   maxNodes: 15,
   relatedProblems: [

--- a/frontend/src/data/algorithms/searching/DFS.tsx
+++ b/frontend/src/data/algorithms/searching/DFS.tsx
@@ -246,7 +246,7 @@ function runGraphDFS(
     const parentId = parentMap.get(currId);
 
     if (parentId) {
-      updateLinkStatus(linkStatusMap, parentId, currId, "visited", false);
+      updateLinkStatus(linkStatusMap, parentId, currId, "target", false);
     }
 
     statusMap[currId] = Status.Target;
@@ -330,6 +330,9 @@ function runGraphDFS(
     if (currId === realEndId) break;
 
     statusMap[currId] = Status.Unfinished; // 歷史軌跡
+    if (parentId) {
+      updateLinkStatus(linkStatusMap, parentId, currId, Status.Unfinished as linkStatus, false);
+    }
 
     const currNode = nodeMap.get(currId);
     if (currNode) {
@@ -366,7 +369,7 @@ function runGraphDFS(
       for (const neighbor of neighbors) {
         // 只有未訪問過的才推入堆疊
         if (!visited.has(neighbor.id)) {
-          updateLinkStatus(linkStatusMap, currId, neighbor.id, "path", false);
+          updateLinkStatus(linkStatusMap, currId, neighbor.id, "prepare", true);
           parentMap.set(neighbor.id, currId);
           // 步數 + 1
           stack.push({ id: neighbor.id, dist: currDist + 1 });
@@ -893,6 +896,10 @@ DFS 的時間複雜度為 O(V + E)，其中 V 是節點數量，E 是邊數量�
   createAnimationSteps: createDFSAnimationSteps,
   actionHandler: dfsActionHandler,
   defaultViewMode: "graph",
+  linkAnimConfig: {
+    animateOn: ["prepare"],
+    directOn: ["target", "complete"],
+  },
   renderActionBar: (props) => <BFSDFSActionBar {...(props as any)} />,
   maxNodes: 15,
   relatedProblems: [

--- a/frontend/src/data/algorithms/searching/dijkstra.tsx
+++ b/frontend/src/data/algorithms/searching/dijkstra.tsx
@@ -151,6 +151,11 @@ export function createDijkstraAnimationSteps(
   const statusMap: Record<string, Status> = {};
   const linkStatusMap: Record<string, linkStatus> = {};
   const visited: Set<string> = new Set();
+  const prev: Record<string, string | null> = {};
+
+  rawNodes.forEach((n: any) => {
+    prev[n.id] = null;
+  });
 
   rawNodes.forEach((n: any) => {
     dist[n.id] = Infinity;
@@ -233,7 +238,6 @@ export function createDijkstraAnimationSteps(
 
     // 提早結束邏輯(有輸入終點時)
     if (endNodeId && u === endNodeId) {
-      statusMap[u] = Status.Complete;
       recordStep(
         `節點 ${u} 是目標終點，且已確定最短路徑 (${dist[u]})，提早結束搜尋！`,
         TAGS.DONE,
@@ -254,7 +258,7 @@ export function createDijkstraAnimationSteps(
 
       if (visited.has(v)) continue; // 已經定案的節點不再更新
 
-      updateLinkStatus(linkStatusMap, u, v, "target", isDirected);
+      updateLinkStatus(linkStatusMap, u, v, "target", true);
       recordStep(
         `檢查相鄰節點 ${v}，經過此邊的權重為 ${weight}`,
         TAGS.CHECK_NEIGHBORS,
@@ -263,9 +267,9 @@ export function createDijkstraAnimationSteps(
       const alt = dist[u] + weight;
       if (alt < dist[v]) {
         dist[v] = alt;
-        // 標記發現的最短路徑邊
+        prev[v] = u;
         statusMap[v] = Status.Prepare;
-        updateLinkStatus(linkStatusMap, u, v, "path", isDirected);
+        updateLinkStatus(linkStatusMap, u, v, "prepare", true);
         recordStep(
           `發現更短路徑，從 ${u} 到 ${v} 的新距離是 ${alt}，更新距離表`,
           TAGS.RELAX_EDGE_TRUE,
@@ -278,8 +282,7 @@ export function createDijkstraAnimationSteps(
         );
       }
 
-      // 檢查完把線的顏色恢復
-      updateLinkStatus(linkStatusMap, u, v, "default", isDirected);
+      updateLinkStatus(linkStatusMap, u, v, "complete", false);
     }
 
     visited.add(u);
@@ -290,8 +293,36 @@ export function createDijkstraAnimationSteps(
     );
   }
 
-  if (!endNodeId || dist[endNodeId] === Infinity) {
+  if (endNodeId && dist[endNodeId] !== Infinity) {
+    // 回溯最短路徑
+    const path: string[] = [];
+    let curr: string | null = endNodeId;
+    while (curr !== null) {
+      path.unshift(curr);
+      curr = prev[curr];
+    }
+
+    // 重置所有狀態，只標記路徑
+    rawNodes.forEach((n: any) => {
+      statusMap[n.id] = Status.Unfinished;
+    });
+    Object.keys(linkStatusMap).forEach((k) => delete linkStatusMap[k]);
+
+    path.forEach((nodeId) => {
+      statusMap[nodeId] = Status.Complete;
+    });
+    for (let i = 0; i < path.length - 1; i++) {
+      updateLinkStatus(linkStatusMap, path[i], path[i + 1], "complete", false);
+    }
+
+    recordStep(
+      `最短路徑：${path.join(" → ")}，總距離 = ${dist[endNodeId]}`,
+      TAGS.DONE,
+    );
+  } else if (!endNodeId) {
     recordStep("演算法執行完畢！所有可達節點的最短路徑皆已找出。", TAGS.DONE);
+  } else {
+    recordStep(`終點 ${endNodeId} 不可達，演算法結束。`, TAGS.DONE);
   }
 
   return steps;
@@ -390,6 +421,10 @@ export const dijkstraConfig: LevelImplementationConfig = {
         ["node-3", "node-2", "6"],
       ],
     },
+  },
+  linkAnimConfig: {
+    animateOn: ["target"],
+    directOn: ["prepare", "complete", "unfinished"],
   },
   createAnimationSteps: createDijkstraAnimationSteps,
   actionHandler: dijkstraActionHandler,

--- a/frontend/src/data/algorithms/sorting/topologicalSort.tsx
+++ b/frontend/src/data/algorithms/sorting/topologicalSort.tsx
@@ -258,9 +258,6 @@ export function createTopologicalSortAnimationSteps(
 
     const stepLinks = remainingEdges.map((e) => {
       let linkStatus = edgeStatus[`${e[0]}->${e[1]}`] as any;
-      if (linkStatus === TopoStatus.Reducing) {
-        linkStatus = Status.Target;
-      }
       return {
         sourceId: e[0],
         targetId: e[1],
@@ -376,6 +373,9 @@ export function createTopologicalSortAnimationSteps(
         nodeStatus[n.id] = TopoStatus.Error;
       }
     });
+    remainingEdges.forEach((e) => {
+      edgeStatus[`${e[0]}->${e[1]}`] = TopoStatus.Error;
+    });
     recordStep(
       `剩下的節點因為互相等待前置條件（入度永遠無法歸零），發生死鎖 (Deadlock)，拓撲排序失敗。`,
       TAGS.CHECK_CYCLE,
@@ -475,6 +475,10 @@ export const topologicalSortConfig: LevelImplementationConfig = {
       ["node-2", "node-3"],
       ["node-3", "node-1"],
     ],
+  },
+  linkAnimConfig: {
+    animateOn: ["reducing"],
+    directOn: ["complete", "unfinished", "error"],
   },
   actionHandler: topoActionHandler,
   createAnimationSteps: createTopologicalSortAnimationSteps,

--- a/frontend/src/modules/core/Render/D3Canvas.tsx
+++ b/frontend/src/modules/core/Render/D3Canvas.tsx
@@ -8,15 +8,17 @@ import {
 } from "react";
 import * as d3 from "d3";
 import { BaseElement } from "../DataLogic/BaseElement";
+import { Node } from "../DataLogic/Node";
 import { renderAll } from "./D3Renderer";
+import { circleBoundaryPoint } from "./linkGeometry";
 import { useZoom } from "@/shared/hooks/useZoom";
 import { useDrag } from "@/shared/hooks/useDrag";
 import CanvasShell from "./CanvasShell";
-import type { BaseCanvasProps } from "@/types/canvasTypes";
+import type { AnimatableCanvasRef, BaseCanvasProps } from "@/types/canvasTypes";
 import { computeUnionBBox } from "./useBoxViewBox";
 import styles from "./D3Canvas.module.scss";
 
-export interface D3CanvasRef {
+export interface D3CanvasRef extends AnimatableCanvasRef {
   getSVGElement: () => SVGSVGElement | null;
 }
 
@@ -40,6 +42,22 @@ export const D3Canvas = forwardRef<D3CanvasRef, BaseCanvasProps>(
   ) => {
     const svgRef = useRef<SVGSVGElement | null>(null);
     const contentRef = useRef<HTMLDivElement | null>(null);
+    const elementsRef = useRef<BaseElement[]>(elements);
+    const animDefsRef = useRef<SVGDefsElement | null>(null);
+    const animStateRef = useRef<Map<string, number>>(new Map());
+    const animatingNodesRef = useRef<Set<string>>(new Set());
+    const isDirectedRef = useRef(isDirected);
+    const shouldHideArrowRef = useRef(false);
+
+    elementsRef.current = elements;
+    isDirectedRef.current = isDirected;
+    const forceHideArrow = ["bfs", "dfs", "binarytree", "bst"].includes(
+      structureType,
+    );
+    shouldHideArrowRef.current =
+      structureType === "graph" || structureType === "dijkstra"
+        ? !isDirected
+        : forceHideArrow;
 
     // 動態 viewBox 狀態 — lazy initializer 確保第 1 幀即使用正確 viewBox，避免初始跳動
     const [dynamicViewBox, setDynamicViewBox] = useState(() => {
@@ -99,7 +117,236 @@ export const D3Canvas = forwardRef<D3CanvasRef, BaseCanvasProps>(
 
     useImperativeHandle(forwardedRef, () => ({
       getSVGElement: () => svgRef.current,
-    }));
+      animateLink(
+        sourceId: string,
+        targetId: string,
+        toColor: string,
+        duration = 1200,
+        onComplete?: () => void,
+      ) {
+        const BLEND = 0.12;
+        const els = elementsRef.current;
+        const srcEl = els.find((e) => String(e.id) === sourceId) as
+          | Node
+          | undefined;
+        const tgtEl = els.find((e) => String(e.id) === targetId) as
+          | Node
+          | undefined;
+        if (!srcEl || !tgtEl) return;
+        if (srcEl.id === tgtEl.id) return;
+
+        const linkEl = d3
+          .select(svgRef.current)
+          .selectAll<SVGPathElement, unknown>("path.link")
+          .filter(
+            (d: unknown) =>
+              !!d &&
+              typeof d === "object" &&
+              "s" in d &&
+              "t" in d &&
+              String((d as { s: { id: unknown } }).s.id) === sourceId &&
+              String((d as { t: { id: unknown } }).t.id) === targetId,
+          )
+          .node();
+        const rawStroke = linkEl?.getAttribute("stroke") ?? "#888";
+        const fromColor = rawStroke.startsWith("url(")
+          ? tgtEl.getColor()
+          : rawStroke;
+
+        const key = `${sourceId}->${targetId}`;
+        const gradId = `d3c-anim-${sourceId}-${targetId}`.replace(
+          /[^a-zA-Z0-9_-]/g,
+          "_",
+        );
+        const arrowMarkerId = `d3c-anim-arrow-${sourceId}-${targetId}`.replace(
+          /[^a-zA-Z0-9_-]/g,
+          "_",
+        );
+
+        const existing = animStateRef.current.get(key);
+        if (existing !== undefined) {
+          cancelAnimationFrame(existing);
+          if (animDefsRef.current) {
+            const ad = d3.select(animDefsRef.current);
+            ad.select(`#${gradId}`).remove();
+            ad.select(`#${arrowMarkerId}`).remove();
+          }
+        }
+
+        const startTime = performance.now();
+        const tick = () => {
+          const svgEl = svgRef.current;
+          const defs = animDefsRef.current;
+          if (!svgEl || !defs) return;
+
+          const s = Math.min((performance.now() - startTime) / duration, 1);
+          const linkT = Math.min(s / 0.75, 1);
+          const frontPct = `${linkT * 100}%`;
+          const blendEndPct = `${Math.min(linkT + BLEND, 1) * 100}%`;
+
+          const srcN = els.find((e) => String(e.id) === sourceId) as
+            | Node
+            | undefined;
+          const tgtN = els.find((e) => String(e.id) === targetId) as
+            | Node
+            | undefined;
+          if (!srcN || !tgtN) return;
+
+          const p1 = circleBoundaryPoint(
+            {
+              x: srcN.position.x,
+              y: srcN.position.y,
+              r: srcN.radius ?? 20,
+            },
+            { x: tgtN.position.x, y: tgtN.position.y },
+          );
+          const p2 = circleBoundaryPoint(
+            {
+              x: tgtN.position.x,
+              y: tgtN.position.y,
+              r: tgtN.radius ?? 20,
+            },
+            { x: srcN.position.x, y: srcN.position.y },
+          );
+
+          const d3Defs = d3.select(defs);
+
+          if (d3Defs.select(`#${gradId}`).empty()) {
+            const g = d3Defs
+              .append("linearGradient")
+              .attr("id", gradId)
+              .attr("gradientUnits", "userSpaceOnUse");
+            g.append("stop").attr("class", "g-s1");
+            g.append("stop").attr("class", "g-s2");
+            g.append("stop").attr("class", "g-s3");
+            g.append("stop").attr("class", "g-s4");
+          }
+          d3Defs
+            .select(`#${gradId}`)
+            .attr("x1", p1.x)
+            .attr("y1", p1.y)
+            .attr("x2", p2.x)
+            .attr("y2", p2.y);
+          d3Defs
+            .select(`#${gradId} .g-s1`)
+            .attr("offset", "0%")
+            .attr("stop-color", toColor);
+          d3Defs
+            .select(`#${gradId} .g-s2`)
+            .attr("offset", frontPct)
+            .attr("stop-color", toColor);
+          d3Defs
+            .select(`#${gradId} .g-s3`)
+            .attr("offset", blendEndPct)
+            .attr("stop-color", fromColor);
+          d3Defs
+            .select(`#${gradId} .g-s4`)
+            .attr("offset", "100%")
+            .attr("stop-color", fromColor);
+
+          d3.select(svgEl)
+            .selectAll<SVGPathElement, unknown>("path.link")
+            .filter(
+              (d: unknown) =>
+                !!d &&
+                typeof d === "object" &&
+                "s" in d &&
+                "t" in d &&
+                String((d as { s: { id: unknown } }).s.id) === sourceId &&
+                String((d as { t: { id: unknown } }).t.id) === targetId,
+            )
+            .attr("stroke", `url(#${gradId})`);
+
+          if (isDirectedRef.current && !shouldHideArrowRef.current) {
+            if (d3Defs.select(`#${arrowMarkerId}`).empty()) {
+              const m = d3Defs
+                .append("marker")
+                .attr("id", arrowMarkerId)
+                .attr("viewBox", "0 -5 10 10")
+                .attr("refX", 10)
+                .attr("refY", 0)
+                .attr("markerWidth", 6)
+                .attr("markerHeight", 6)
+                .attr("orient", "auto");
+              m.append("path").attr("d", "M0,-5L10,0L0,5");
+              d3.select(svgEl)
+                .selectAll<SVGPathElement, unknown>("path.link")
+                .filter(
+                  (d: unknown) =>
+                    !!d &&
+                    typeof d === "object" &&
+                    "s" in d &&
+                    "t" in d &&
+                    String((d as { s: { id: unknown } }).s.id) === sourceId &&
+                    String((d as { t: { id: unknown } }).t.id) === targetId,
+                )
+                .attr("marker-end", `url(#${arrowMarkerId})`);
+            }
+            const arrowT = Math.max(0, (linkT - (1 - BLEND)) / BLEND);
+            d3Defs
+              .select(`#${arrowMarkerId} path`)
+              .attr(
+                "fill",
+                d3.interpolateRgb(fromColor, toColor)(Math.min(arrowT, 1)),
+              );
+          }
+
+          if (s < 1) {
+            animStateRef.current.set(key, requestAnimationFrame(tick));
+          } else {
+            d3.select(svgEl)
+              .selectAll<SVGPathElement, unknown>("path.link")
+              .filter(
+                (d: unknown) =>
+                  !!d &&
+                  typeof d === "object" &&
+                  "s" in d &&
+                  "t" in d &&
+                  String((d as { s: { id: unknown } }).s.id) === sourceId &&
+                  String((d as { t: { id: unknown } }).t.id) === targetId,
+              )
+              .attr("stroke", toColor);
+            d3Defs.select(`#${gradId}`).remove();
+
+            if (isDirectedRef.current && !shouldHideArrowRef.current) {
+              d3Defs.select(`#${arrowMarkerId}`).remove();
+              d3.select(svgEl)
+                .selectAll<SVGPathElement, unknown>("path.link")
+                .filter(
+                  (d: unknown) =>
+                    !!d &&
+                    typeof d === "object" &&
+                    "s" in d &&
+                    "t" in d &&
+                    String((d as { s: { id: unknown } }).s.id) === sourceId &&
+                    String((d as { t: { id: unknown } }).t.id) === targetId,
+                )
+                .attr("marker-end", "url(#arrowhead)");
+            } else if (shouldHideArrowRef.current) {
+              d3Defs.select(`#${arrowMarkerId}`).remove();
+              d3.select(svgEl)
+                .selectAll<SVGPathElement, unknown>("path.link")
+                .filter(
+                  (d: unknown) =>
+                    !!d &&
+                    typeof d === "object" &&
+                    "s" in d &&
+                    "t" in d &&
+                    String((d as { s: { id: unknown } }).s.id) === sourceId &&
+                    String((d as { t: { id: unknown } }).t.id) === targetId,
+                )
+                .attr("marker-end", "none");
+            }
+
+            animStateRef.current.delete(key);
+            onComplete?.();
+          }
+        };
+
+        animStateRef.current.set(key, requestAnimationFrame(tick));
+      },
+    }),
+    []);
 
     useEffect(() => {
       if (!enableZoom) return;
@@ -152,6 +399,20 @@ export const D3Canvas = forwardRef<D3CanvasRef, BaseCanvasProps>(
       const svgElement = svgRef.current;
       if (!svgElement) return;
 
+      const svg = d3.select(svgElement);
+      let animDefs = svg.select<SVGDefsElement>("defs#anim-defs");
+      if (animDefs.empty()) {
+        animDefs = svg
+          .append("defs")
+          .attr("id", "anim-defs") as unknown as d3.Selection<
+          SVGDefsElement,
+          unknown,
+          null,
+          undefined
+        >;
+      }
+      animDefsRef.current = animDefs.node();
+
       // Phase 1: 渲染當前步驟的實際元素（需先執行以取得 containerBBox）
       const { containerBBox } = renderAll(
         svgElement,
@@ -160,6 +421,7 @@ export const D3Canvas = forwardRef<D3CanvasRef, BaseCanvasProps>(
         structureType,
         isDirected,
         statusColorMap,
+        { animStateRef, animatingNodesRef },
       );
 
       // Phase 2: ViewBox 計算 — 只在 allStepsElements 改變時執行（新動畫觸發）
@@ -197,6 +459,10 @@ export const D3Canvas = forwardRef<D3CanvasRef, BaseCanvasProps>(
         if (svgElement) {
           d3.select(svgElement).selectAll("*").interrupt();
         }
+        animStateRef.current.forEach((id) => cancelAnimationFrame(id));
+        animStateRef.current.clear();
+        animDefsRef.current = null;
+        animatingNodesRef.current.clear();
       };
     }, [
       elements,

--- a/frontend/src/modules/core/Render/D3Renderer.tsx
+++ b/frontend/src/modules/core/Render/D3Renderer.tsx
@@ -1,9 +1,14 @@
 import * as d3 from "d3";
+import type { MutableRefObject } from "react";
 import { BaseElement } from "../DataLogic/BaseElement";
 import { Node } from "../DataLogic/Node";
 import { Box } from "../DataLogic/Box";
 import { LinkManager } from "../DataLogic/LinkManager";
-import type { StatusColorMap } from "@/types/statusConfig";
+import {
+  buildStatusColorMap,
+  DEFAULT_STATUS_CONFIG,
+  type StatusColorMap,
+} from "@/types/statusConfig";
 import { Pointer } from "../DataLogic/Pointer";
 import {
   circleBoundaryPoint,
@@ -15,15 +20,29 @@ import {
 } from "./linkGeometry";
 import "./D3Renderer.module.scss";
 
-export type linkStatus = "default" | "visited" | "path" | "target" | "complete";
+export type linkStatus = "default" | "unfinished" | "visited" | "path" | "prepare" | "target" | "complete";
 
 export const linkStatusColorMap: Record<linkStatus, string> = {
   default: "#888",
+  unfinished: "#1d79cfff",
   visited: "#1d79cfff",
   path: "yellow",
+  prepare: "#f59e0b",
   target: "orange",
   complete: "#46f336ff",
 };
+
+/** 未傳入 statusColorMap 時的預設對照（與 buildStatusColorMap(DEFAULT_STATUS_CONFIG) 一致） */
+export const defaultStatusColorMap: StatusColorMap =
+  buildStatusColorMap(DEFAULT_STATUS_CONFIG);
+
+export function getLinkColor(
+  linkStatus: string | undefined,
+  statusColorMap: StatusColorMap,
+): string {
+  if (!linkStatus || linkStatus === "default") return "#888";
+  return statusColorMap[linkStatus] ?? "#888";
+}
 
 export interface Link {
   key: string;
@@ -250,6 +269,10 @@ export function renderAll(
   structureType: string = "linkedlist",
   isDirected: boolean = true,
   statusColorMap?: StatusColorMap,
+  animGuards?: {
+    animStateRef: MutableRefObject<Map<string, number>>;
+    animatingNodesRef: MutableRefObject<Set<string>>;
+  },
 ): { containerBBox: BBox | null } {
   // Inject custom color map into all elements if provided
   if (statusColorMap) {
@@ -261,12 +284,6 @@ export function renderAll(
   const svg = d3.select(svgEl);
   const transitionDuration = 500; // 統一動畫時間
   const transitionEase = d3.easeQuadOut;
-
-  const getColor = (status?: string) => {
-    return (
-      linkStatusColorMap[status as linkStatus] || linkStatusColorMap.default
-    );
-  };
 
   // Pre-calculation for AutoScale(Grouping Support)
   const scaleYMap = new Map<string, d3.ScaleLinear<number, number>>();
@@ -342,11 +359,12 @@ export function renderAll(
     structureType === "graph" || structureType === "dijkstra"
       ? !isDirected
       : forceHideArrow;
-  const markerUrl = shouldHideArrow ? "none" : "url(#arrowhead-default)";
-  const defs = svg.selectAll("defs").data([null]);
-  const defsEnter = defs.enter().append("defs");
+  const markerUrl = shouldHideArrow ? "none" : "url(#arrowhead)";
   if (svg.select("#arrowhead").empty()) {
-    defsEnter
+    const defsParent = svg.select("defs").empty()
+      ? svg.append("defs")
+      : svg.select("defs");
+    defsParent
       .append("marker")
       .attr("id", "arrowhead")
       .attr("viewBox", "0 -5 10 10")
@@ -357,27 +375,8 @@ export function renderAll(
       .attr("orient", "auto")
       .append("path")
       .attr("d", "M0,-5L10,0L0,5")
-      .attr("fill", "#888");
+      .attr("fill", "context-stroke");
   }
-
-  Object.entries(linkStatusColorMap).forEach(([status, color]) => {
-    // 檢查是否已存在，避免重複 append (雖然 data([null]) 會擋，但保險起見)
-    if (svg.select(`#arrowhead-${status}`).empty()) {
-      svg
-        .select("defs")
-        .append("marker")
-        .attr("id", `arrowhead-${status}`)
-        .attr("viewBox", "0 -5 10 10")
-        .attr("refX", 10)
-        .attr("refY", 0)
-        .attr("markerWidth", 6)
-        .attr("markerHeight", 6)
-        .attr("orient", "auto")
-        .append("path")
-        .attr("d", "M0,-5L10,0L0,5")
-        .attr("fill", color);
-    }
-  });
 
   // 根 <g>
   const root = svg.selectAll<SVGGElement, null>("g.scene").data([null]);
@@ -511,21 +510,14 @@ export function renderAll(
   // 3. Merge & Update：更新所有群組的位置與狀態
   const mergedLinkGroups = linkGroupEnter.merge(linkGroups as any);
 
-  // 更新線條動畫
-  mergedLinkGroups
-    .select("path.link")
-    .attr("marker-end", (d) => {
-      if (shouldHideArrow) return "none";
-      const status =
-        d.status && d.status in linkStatusColorMap ? d.status : "default";
-      return `url(#arrowhead-${status})`;
-    })
-    .transition()
-    .duration(transitionDuration)
-    .ease(transitionEase)
-    .attr("d", (d) => {
-      const hasReverse = linkSet.has(`${d.t.id}->${d.s.id}`);
-      const pathOffset = isDirected && hasReverse ? 8 : 0;
+  // 更新線條動畫（動畫中的 link 由 animateLink 接管，不覆寫）
+  mergedLinkGroups.each(function (d) {
+    const linkKey = `${d.s.id}->${d.t.id}`;
+    if (animGuards?.animStateRef.current.has(linkKey)) return;
+
+    const hasReverse = linkSet.has(`${d.t.id}->${d.s.id}`);
+    const pathOffset = isDirected && hasReverse ? 8 : 0;
+    const pathD = (() => {
       if (
         isNaN(d.s.position.x) ||
         isNaN(d.s.position.y) ||
@@ -542,9 +534,22 @@ export function renderAll(
         { x: d.t.position.x, y: d.t.position.y, r: d.t.radius ?? 20 },
         pathOffset,
       );
-    })
-    .attr("stroke", (d) => getColor(d.status))
-    .attr("stroke-width", 2);
+    })();
+
+    d3
+      .select(this)
+      .select("path.link")
+      .attr("marker-end", shouldHideArrow ? "none" : "url(#arrowhead)")
+      .transition()
+      .duration(transitionDuration)
+      .ease(transitionEase)
+      .attr("d", pathD)
+      .attr(
+        "stroke",
+        getLinkColor(d.status, statusColorMap ?? defaultStatusColorMap),
+      )
+      .attr("stroke-width", 2);
+  });
 
   // 更新權重標籤的位置 (放在線的中心點)
   mergedLinkGroups.each(function (d) {
@@ -696,6 +701,8 @@ export function renderAll(
 
   // 個別型別屬性 + 描述文字
   merged.each(function (d) {
+    if (animGuards?.animatingNodesRef.current.has(String(d.id))) return;
+
     const g = d3.select(this);
 
     if (d.kind === "node" || d instanceof Node) {

--- a/frontend/src/modules/core/Render/GraphCanvas.tsx
+++ b/frontend/src/modules/core/Render/GraphCanvas.tsx
@@ -1,4 +1,11 @@
-import { useRef, useEffect, useMemo, useCallback } from "react";
+import {
+  useRef,
+  useEffect,
+  useMemo,
+  useCallback,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import {
   forceSimulation,
   forceLink,
@@ -10,14 +17,18 @@ import {
   zoom as d3Zoom,
   zoomIdentity,
   easeQuadOut,
+  interpolateRgb,
 } from "d3";
 import type { SimulationNodeDatum, SimulationLinkDatum } from "d3";
 import { Node } from "../DataLogic/Node";
 import { Box } from "../DataLogic/Box";
-import type { Link } from "./D3Renderer";
-import { linkStatusColorMap } from "./D3Renderer";
+import {
+  defaultStatusColorMap,
+  getLinkColor,
+  type Link,
+} from "./D3Renderer";
 import CanvasShell from "./CanvasShell";
-import type { BaseCanvasProps } from "@/types/canvasTypes";
+import type { AnimatableCanvasRef, BaseCanvasProps } from "@/types/canvasTypes";
 import { useBoxViewBox } from "./useBoxViewBox";
 import {
   circleBoundaryPoint,
@@ -65,6 +76,8 @@ function deduplicateLinks(links: Link[], isDirected: boolean): GSimLink[] {
 
 export type GraphCanvasProps = BaseCanvasProps;
 
+export interface GraphCanvasRef extends AnimatableCanvasRef {}
+
 interface GSimNode extends SimulationNodeDatum {
   id: string;
   radius: number;
@@ -79,20 +92,24 @@ interface GSimLink extends SimulationLinkDatum<GSimNode> {
   weight?: number | string;
 }
 
-export function GraphCanvas({
-  elements,
-  links = [],
-  width = 800,
-  height = 500,
-  isDirected = false,
-  statusColorMap,
-  statusConfig,
-  enableZoom = true,
-  enablePan = true,
-  allStepsElements,
-  structureType,
-  disableAutoFit = false,
-}: GraphCanvasProps) {
+export const GraphCanvas = forwardRef<GraphCanvasRef, GraphCanvasProps>(
+  function GraphCanvas(
+    {
+      elements,
+      links = [],
+      width = 800,
+      height = 500,
+      isDirected = false,
+      statusColorMap,
+      statusConfig,
+      enableZoom = true,
+      enablePan = true,
+      allStepsElements,
+      structureType,
+      disableAutoFit = false,
+    },
+    ref,
+  ) {
   const svgRef = useRef<SVGSVGElement>(null);
   const simulationRef = useRef<ReturnType<
     typeof forceSimulation<GSimNode>
@@ -104,6 +121,13 @@ export function GraphCanvas({
   const prevLinkKeyRef = useRef<string>("");
   const seenSelfLoopsRef = useRef<Set<string>>(new Set());
   const linkSetRef = useRef<Set<string>>(new Set());
+  const simNodesRef = useRef<GSimNode[]>([]);
+  const isDirectedRef = useRef(isDirected);
+  const animDefsRef = useRef<SVGDefsElement | null>(null);
+  const animStateRef = useRef<Map<string, number>>(new Map());
+  const nodeMapRef = useRef<Map<string, Node>>(new Map());
+
+  isDirectedRef.current = isDirected;
 
   // 動態 viewBox：只向外擴張（用於 Box 元素超出預設範圍時）
   const {
@@ -153,23 +177,21 @@ export function GraphCanvas({
 
     if (nodeElements.length === 0) return;
 
-    // 箭頭標記（有向圖）— 每個 status 各一個，顏色跟著邊的狀態走
+    // 箭頭標記（有向圖）— 單一 marker，fill 繼承 stroke（context-stroke）
     if (isDirected) {
       const defs = svg.append("defs");
-      Object.entries(linkStatusColorMap).forEach(([status, color]) => {
-        defs
-          .append("marker")
-          .attr("id", `gc-arrowhead-${status}`)
-          .attr("viewBox", "0 -5 10 10")
-          .attr("refX", 10)
-          .attr("refY", 0)
-          .attr("markerWidth", 6)
-          .attr("markerHeight", 6)
-          .attr("orient", "auto")
-          .append("path")
-          .attr("d", "M0,-5L10,0L0,5")
-          .attr("fill", color);
-      });
+      defs
+        .append("marker")
+        .attr("id", "gc-arrowhead")
+        .attr("viewBox", "0 -5 10 10")
+        .attr("refX", 10)
+        .attr("refY", 0)
+        .attr("markerWidth", 6)
+        .attr("markerHeight", 6)
+        .attr("orient", "auto")
+        .append("path")
+        .attr("d", "M0,-5L10,0L0,5")
+        .attr("fill", "context-stroke");
     }
 
     // Zoom + Pan（D3 zoom 套用在 SVG，transform 作用於 mainGroup）
@@ -181,6 +203,9 @@ export function GraphCanvas({
       });
 
     const mainGroup = svg.append("g").attr("class", "main-group");
+    const animDefs = mainGroup.append("defs").attr("id", "gc-anim-defs");
+    animDefsRef.current = animDefs.node();
+
     zoomBehavior.on("zoom", (event) => {
       mainGroup.attr("transform", event.transform.toString());
     });
@@ -329,7 +354,7 @@ export function GraphCanvas({
       .attr("stroke", "#888")
       .attr("stroke-width", 2)
       .attr("fill", "none")
-      .attr("marker-end", isDirected ? "url(#gc-arrowhead-default)" : "none")
+      .attr("marker-end", isDirected ? "url(#gc-arrowhead)" : "none")
       .attr("data-anim", (d) => {
         if (d.sourceId !== d.targetId) return null;
         if (seenSelfLoopsRef.current.has(d.sourceId)) return null;
@@ -464,6 +489,8 @@ export function GraphCanvas({
 
     // Tick：更新座標 + 寫入快取（動態選取以支援 Effect 2 新增的 link）
     simulation.on("tick", () => {
+      simNodesRef.current = simNodes;
+
       const svgEl = svgRef.current;
       if (!svgEl) return;
 
@@ -610,6 +637,9 @@ export function GraphCanvas({
 
     return () => {
       simulation.stop();
+      animStateRef.current.forEach((id) => cancelAnimationFrame(id));
+      animStateRef.current.clear();
+      animDefsRef.current = null;
     };
   }, [nodeIds, width, height, isDirected, structureType]); // links 不放入，addEdge 不重建
 
@@ -683,7 +713,7 @@ export function GraphCanvas({
             .attr("fill", "none")
             .attr(
               "marker-end",
-              isDirected ? "url(#gc-arrowhead-default)" : "none",
+              isDirected ? "url(#gc-arrowhead)" : "none",
             )
             .attr("data-anim", (d) => {
               if (d.sourceId !== d.targetId) return null;
@@ -872,6 +902,16 @@ export function GraphCanvas({
     }
 
     const nodeMap = new Map(nodeElements.map((e) => [e.id, e]));
+    nodeMapRef.current = nodeMap;
+
+    const linksMap = new Map<string, (typeof links)[0]>();
+    links.forEach((l) => {
+      const k = isDirected ? `${l.sourceId}->${l.targetId}` : [l.sourceId, l.targetId].sort().join("--");
+      const existing = linksMap.get(k);
+      if (!existing || l.status !== undefined) {
+        linksMap.set(k, l);
+      }
+    });
 
     d3Select(svgRef.current)
       .selectAll<SVGCircleElement, GSimNode>(".gc-node")
@@ -912,22 +952,24 @@ export function GraphCanvas({
           .attr("fill", "#ccc");
       });
 
-    // 更新 link 樣式（stroke + marker-end 顏色同步）
+    // 更新 link 樣式（link.status → statusColorMap；動畫中由 animateLink 接管）
     d3Select(svgRef.current)
       .selectAll<SVGPathElement, GSimLink>(".gc-link")
       .each(function (d) {
         if (!d) return;
-        const status = d.status || "default";
-        const markerStatus = status in linkStatusColorMap ? status : "default";
-        const color =
-          linkStatusColorMap[status as keyof typeof linkStatusColorMap] ??
-          linkStatusColorMap.default;
+        const animKey = `${d.sourceId}->${d.targetId}`;
+        if (animStateRef.current.has(animKey)) return;
+        const propKey = isDirected
+          ? animKey
+          : [d.sourceId, d.targetId].sort().join("--");
+        const linkData = linksMap.get(propKey);
+        const color = getLinkColor(
+          linkData?.status,
+          statusColorMap ?? defaultStatusColorMap,
+        );
         d3Select(this)
           .attr("stroke", color)
-          .attr(
-            "marker-end",
-            isDirected ? `url(#gc-arrowhead-${markerStatus})` : "none",
-          );
+          .attr("marker-end", isDirected ? "url(#gc-arrowhead)" : "none");
       });
 
     // 更新 weight 文字顏色（target 狀態→橙色，其他→白色，與 D3Renderer 一致）
@@ -936,12 +978,214 @@ export function GraphCanvas({
       .selectAll<SVGGElement, GSimLink>("g.gc-weight-group")
       .each(function (d) {
         if (!d || d.weight == null) return;
-        const status = d.status || "default";
+        const propKey = isDirected
+          ? `${d.sourceId}->${d.targetId}`
+          : [d.sourceId, d.targetId].sort().join("--");
+        const status =
+          linksMap.get(propKey)?.status ?? d.status ?? "default";
         d3Select(this)
           .select("text.gc-weight-text")
           .attr("fill", status === "target" ? "#ffb74d" : "#fff");
       });
-  }, [elements, nodeElements, isDirected]);
+  }, [elements, nodeElements, isDirected, links, statusColorMap]);
+
+  useImperativeHandle(ref, () => ({
+    animateLink(
+      sourceId: string,
+      targetId: string,
+      toColor: string,
+      duration = 1200,
+      onComplete?: () => void,
+    ) {
+      const BLEND = 0.12;
+      if (sourceId === targetId) return;
+
+      // Try caller's direction first; fallback to reverse for undirected graphs.
+      // elemSourceId/elemTargetId = the direction the SVG element is actually stored.
+      // sourceId/targetId (caller) = the intended traversal direction for gradient.
+      let elemSourceId = sourceId;
+      let elemTargetId = targetId;
+      let linkEl = d3Select(svgRef.current)
+        .selectAll<SVGPathElement, GSimLink>(".gc-link")
+        .filter((d) => d.sourceId === sourceId && d.targetId === targetId)
+        .node();
+
+      if (!linkEl) {
+        elemSourceId = targetId;
+        elemTargetId = sourceId;
+        linkEl = d3Select(svgRef.current)
+          .selectAll<SVGPathElement, GSimLink>(".gc-link")
+          .filter((d) => d.sourceId === elemSourceId && d.targetId === elemTargetId)
+          .node();
+      }
+
+      if (!linkEl) {
+        onComplete?.();
+        return;
+      }
+
+      const rawStroke = linkEl.getAttribute("stroke") ?? "#888";
+      const fromColor = rawStroke.startsWith("url(")
+        ? nodeMapRef.current.get(targetId)?.getColor() ?? "#888"
+        : rawStroke;
+
+      if (fromColor === toColor) {
+        onComplete?.();
+        return;
+      }
+
+      // key uses caller's direction for deduplication; elemKey guards the actual element.
+      const key = `${sourceId}->${targetId}`;
+      const elemKey = `${elemSourceId}->${elemTargetId}`;
+      const gradId = `gc-anim-${sourceId}-${targetId}`.replace(
+        /[^a-zA-Z0-9_-]/g,
+        "_",
+      );
+      const arrowMarkerId = `gc-anim-arrow-${sourceId}-${targetId}`.replace(
+        /[^a-zA-Z0-9_-]/g,
+        "_",
+      );
+
+      const existing = animStateRef.current.get(key);
+      if (existing !== undefined) {
+        cancelAnimationFrame(existing);
+        if (animDefsRef.current) {
+          const ad = d3Select(animDefsRef.current);
+          ad.select(`#${gradId}`).remove();
+          ad.select(`#${arrowMarkerId}`).remove();
+        }
+      }
+
+      const setAnimState = (id: number) => {
+        animStateRef.current.set(key, id);
+        if (elemKey !== key) animStateRef.current.set(elemKey, id);
+      };
+      const deleteAnimState = () => {
+        animStateRef.current.delete(key);
+        if (elemKey !== key) animStateRef.current.delete(elemKey);
+      };
+
+      const elemFilter = (d: GSimLink) =>
+        d.sourceId === elemSourceId && d.targetId === elemTargetId;
+
+      const startTime = performance.now();
+      const tick = () => {
+        const svgEl = svgRef.current;
+        const defs = animDefsRef.current;
+        if (!svgEl || !defs) return;
+
+        const s = Math.min((performance.now() - startTime) / duration, 1);
+        const linkT = s;
+        const frontPct = `${linkT * 100}%`;
+        const blendEndPct = `${Math.min(linkT + BLEND, 1) * 100}%`;
+
+        // Positions use caller's sourceId/targetId so gradient flows in traversal direction.
+        const nodes = simNodesRef.current;
+        const src = nodes.find((n) => n.id === sourceId);
+        const tgt = nodes.find((n) => n.id === targetId);
+        if (!src || !tgt) return;
+
+        const p1 = circleBoundaryPoint(
+          { x: src.x ?? 0, y: src.y ?? 0, r: src.radius },
+          { x: tgt.x ?? 0, y: tgt.y ?? 0 },
+        );
+        const p2 = circleBoundaryPoint(
+          { x: tgt.x ?? 0, y: tgt.y ?? 0, r: tgt.radius },
+          { x: src.x ?? 0, y: src.y ?? 0 },
+        );
+
+        const d3Defs = d3Select(defs);
+
+        if (d3Defs.select(`#${gradId}`).empty()) {
+          const g = d3Defs
+            .append("linearGradient")
+            .attr("id", gradId)
+            .attr("gradientUnits", "userSpaceOnUse");
+          g.append("stop").attr("class", "g-s1");
+          g.append("stop").attr("class", "g-s2");
+          g.append("stop").attr("class", "g-s3");
+          g.append("stop").attr("class", "g-s4");
+        }
+        d3Defs
+          .select(`#${gradId}`)
+          .attr("x1", p1.x)
+          .attr("y1", p1.y)
+          .attr("x2", p2.x)
+          .attr("y2", p2.y);
+        d3Defs
+          .select(`#${gradId} .g-s1`)
+          .attr("offset", "0%")
+          .attr("stop-color", toColor);
+        d3Defs
+          .select(`#${gradId} .g-s2`)
+          .attr("offset", frontPct)
+          .attr("stop-color", toColor);
+        d3Defs
+          .select(`#${gradId} .g-s3`)
+          .attr("offset", blendEndPct)
+          .attr("stop-color", fromColor);
+        d3Defs
+          .select(`#${gradId} .g-s4`)
+          .attr("offset", "100%")
+          .attr("stop-color", fromColor);
+
+        // Apply gradient to the actual element (may differ from caller's direction).
+        d3Select(svgEl)
+          .selectAll<SVGPathElement, GSimLink>(".gc-link")
+          .filter(elemFilter)
+          .attr("stroke", `url(#${gradId})`);
+
+        if (isDirectedRef.current) {
+          if (d3Defs.select(`#${arrowMarkerId}`).empty()) {
+            const m = d3Defs
+              .append("marker")
+              .attr("id", arrowMarkerId)
+              .attr("viewBox", "0 -5 10 10")
+              .attr("refX", 10)
+              .attr("refY", 0)
+              .attr("markerWidth", 6)
+              .attr("markerHeight", 6)
+              .attr("orient", "auto");
+            m.append("path").attr("d", "M0,-5L10,0L0,5");
+            d3Select(svgEl)
+              .selectAll<SVGPathElement, GSimLink>(".gc-link")
+              .filter(elemFilter)
+              .attr("marker-end", `url(#${arrowMarkerId})`);
+          }
+          const arrowT = Math.max(0, (linkT - (1 - BLEND)) / BLEND);
+          d3Defs
+            .select(`#${arrowMarkerId} path`)
+            .attr(
+              "fill",
+              interpolateRgb(fromColor, toColor)(Math.min(arrowT, 1)),
+            );
+        }
+
+        if (s < 1) {
+          setAnimState(requestAnimationFrame(tick));
+        } else {
+          d3Select(svgEl)
+            .selectAll<SVGPathElement, GSimLink>(".gc-link")
+            .filter(elemFilter)
+            .attr("stroke", toColor);
+          d3Defs.select(`#${gradId}`).remove();
+
+          if (isDirectedRef.current) {
+            d3Defs.select(`#${arrowMarkerId}`).remove();
+            d3Select(svgEl)
+              .selectAll<SVGPathElement, GSimLink>(".gc-link")
+              .filter(elemFilter)
+              .attr("marker-end", "url(#gc-arrowhead)");
+          }
+
+          deleteAnimState();
+          onComplete?.();
+        }
+      };
+
+      setAnimState(requestAnimationFrame(tick));
+    },
+  }));
 
   return (
     <CanvasShell
@@ -959,3 +1203,4 @@ export function GraphCanvas({
     </CanvasShell>
   );
 }
+);

--- a/frontend/src/pages/Tutorial/Tutorial.tsx
+++ b/frontend/src/pages/Tutorial/Tutorial.tsx
@@ -1,4 +1,11 @@
-import { useState, useEffect, useMemo, useRef, Suspense } from "react";
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  useCallback,
+  Suspense,
+} from "react";
 import { tutorialService } from '@/services/tutorialService';
 import { useAuth } from '@/shared/contexts/AuthContext';
 import { useParams } from "react-router-dom";
@@ -8,12 +15,19 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import Breadcrumb from "@/shared/components/Breadcrumb";
 import Button from "@/shared/components/Button";
-import { D3Canvas } from "@/modules/core/Render/D3Canvas";
-import { GraphCanvas } from "@/modules/core/Render/GraphCanvas";
+import { D3Canvas, type D3CanvasRef } from "@/modules/core/Render/D3Canvas";
+import {
+  GraphCanvas,
+  type GraphCanvasRef,
+} from "@/modules/core/Render/GraphCanvas";
+import type { AnimatableCanvasRef } from "@/types/canvasTypes";
 import ControlBar from "@/modules/core/components/ControlBar";
 import { toast } from "@/shared/components/Toast";
 import type { BreadcrumbItem } from "@/types";
-import type { AlgorithmViewMode } from "@/types/implementation";
+import {
+  DEFAULT_LINK_ANIM_CONFIG,
+  type AlgorithmViewMode,
+} from "@/types/implementation";
 import { getImplementationByLevelId } from "@/services/ImplementationService";
 import PanelHeader from "./components/PanelHeader";
 import { PANEL_REGISTRY } from "./components/PanelRegistry";
@@ -60,6 +74,10 @@ interface CanvasPanelProps {
   handleReset: () => void;
   setPlaybackSpeed: (speed: number) => void;
   handleStepChange: (step: number) => void;
+
+  graphCanvasRef: React.RefObject<GraphCanvasRef | null>;
+  d3CanvasRef: React.RefObject<D3CanvasRef | null>;
+  useGraphCanvas: boolean;
 }
 
 const CanvasPanel = ({
@@ -74,7 +92,7 @@ const CanvasPanel = ({
   currentStatusColorMap,
   currentStatusConfig,
   isDirected,
-  viewMode,
+  viewMode: _viewMode,
   isPlaying,
   currentStep,
   activeStepsLength,
@@ -86,6 +104,9 @@ const CanvasPanel = ({
   handleReset,
   setPlaybackSpeed,
   handleStepChange,
+  graphCanvasRef,
+  d3CanvasRef,
+  useGraphCanvas,
 }: CanvasPanelProps) => {
   const {
     attributes,
@@ -109,13 +130,6 @@ const CanvasPanel = ({
     opacity: isDragging ? 0 : 1,
   };
 
-  const useGraphCanvas =
-    topicTypeConfig?.id === "graph" ||
-    topicTypeConfig?.id === "dijkstra" ||
-    topicTypeConfig?.id === "topological-sort" ||
-    ((topicTypeConfig?.id === "bfs" || topicTypeConfig?.id === "dfs") &&
-      viewMode !== "grid");
-
   return (
     <Panel
       id="canvas-panel"
@@ -137,6 +151,7 @@ const CanvasPanel = ({
         <div ref={canvasContainerRef} className={styles.visualizationArea}>
           {useGraphCanvas ? (
             <GraphCanvas
+              ref={graphCanvasRef}
               elements={currentStepData?.elements || []}
               allStepsElements={allStepsElements}
               links={currentLinks}
@@ -150,6 +165,7 @@ const CanvasPanel = ({
             />
           ) : (
             <D3Canvas
+              ref={d3CanvasRef}
               elements={currentStepData?.elements || []}
               allStepsElements={allStepsElements}
               links={currentLinks}
@@ -369,6 +385,11 @@ function TutorialContent() {
   const rightPanelRef = useRef<PanelImperativeHandle>(null);
   const canvasPanelRef = useRef<PanelImperativeHandle>(null);
   const inspectorPanelRef = useRef<PanelImperativeHandle>(null);
+  const graphCanvasRef = useRef<GraphCanvasRef | null>(null);
+  const d3CanvasRef = useRef<D3CanvasRef | null>(null);
+  const isAnimatingRef = useRef(false);
+  const isPlayingRef = useRef(false);
+  const handleNextRef = useRef<() => void>(() => {});
 
   // Collapse states (使用 context 的 collapsed state)
   const isLeftPanelCollapsed = collapsedPanels.has("codeEditor");
@@ -515,6 +536,16 @@ function TutorialContent() {
   const [isDirected, setIsDirected] = useState(false);
   const [renderedIsDirected, setRenderedIsDirected] = useState(false);
 
+  const useGraphCanvas = useMemo(
+    () =>
+      topicTypeConfig?.id === "graph" ||
+      topicTypeConfig?.id === "dijkstra" ||
+      topicTypeConfig?.id === "topological-sort" ||
+      ((topicTypeConfig?.id === "bfs" || topicTypeConfig?.id === "dfs") &&
+        viewMode !== "grid"),
+    [topicTypeConfig?.id, viewMode],
+  );
+
   // 計算目前的動畫步驟數據
   const currentStepData = activeSteps[currentStep];
 
@@ -570,16 +601,10 @@ function TutorialContent() {
   useEffect(() => {
     if (!isPlaying) return;
     const interval = setInterval(() => {
-      setCurrentStep((prevStep) => {
-        if (prevStep >= activeSteps.length - 1) {
-          setIsPlaying(false);
-          return prevStep;
-        }
-        return prevStep + 1;
-      });
+      handleNextRef.current();
     }, 1000 / playbackSpeed);
     return () => clearInterval(interval);
-  }, [isPlaying, playbackSpeed, activeSteps.length]);
+  }, [isPlaying, playbackSpeed]);
 
   const allStepsElements = useMemo(() => {
     return activeSteps.map((step) => step?.elements ?? []);
@@ -763,8 +788,86 @@ function TutorialContent() {
 
   const handlePlay = () => setIsPlaying(true);
   const handlePause = () => setIsPlaying(false);
-  const handleNext = () =>
-    setCurrentStep((prev) => Math.min(prev + 1, activeSteps.length - 1));
+
+  isPlayingRef.current = isPlaying;
+
+  const handleNext = useCallback(() => {
+    if (currentStep >= activeSteps.length - 1) {
+      setIsPlaying(false);
+      return;
+    }
+    if (isAnimatingRef.current) return;
+
+    const nextStepIndex = currentStep + 1;
+    const nextStep = activeSteps[nextStepIndex];
+
+    const activeCanvas: AnimatableCanvasRef | null = useGraphCanvas
+      ? graphCanvasRef.current
+      : d3CanvasRef.current;
+
+    if (!activeCanvas || !nextStep?.links) {
+      setCurrentStep(nextStepIndex);
+      return;
+    }
+
+    const linkAnimConfig =
+      topicTypeConfig?.linkAnimConfig ?? DEFAULT_LINK_ANIM_CONFIG;
+
+    const currentLinksMap = new Map<string, Link>(
+      currentLinks.map((l: Link) => [l.key, l]),
+    );
+    const seenEdgePairs = new Set<string>();
+    const changedLinks = (nextStep.links as Link[]).filter((l: Link) => {
+      const prev = currentLinksMap.get(l.key);
+      const statusChanged = l.status !== (prev?.status ?? "default");
+      const shouldAnimate = linkAnimConfig.animateOn.includes(l.status ?? "");
+      if (!statusChanged || !shouldAnimate) return false;
+      const edgePair = [l.sourceId, l.targetId].sort().join(":");
+      if (seenEdgePairs.has(edgePair)) return false;
+      seenEdgePairs.add(edgePair);
+      return true;
+    });
+
+    if (changedLinks.length === 0) {
+      setCurrentStep(nextStepIndex);
+      return;
+    }
+
+    const gc = activeCanvas;
+    isAnimatingRef.current = true;
+    let completed = 0;
+    const duration = Math.round((isPlayingRef.current ? 800 : 1200) / playbackSpeed);
+
+    changedLinks.forEach((link) => {
+      const toColor = currentStatusColorMap
+        ? (currentStatusColorMap[link.status ?? ""] ?? "#888")
+        : "#888";
+
+      gc.animateLink(
+        link.sourceId,
+        link.targetId,
+        toColor,
+        duration,
+        () => {
+          completed += 1;
+          if (completed === changedLinks.length) {
+            isAnimatingRef.current = false;
+            setCurrentStep(nextStepIndex);
+          }
+        },
+      );
+    });
+  }, [
+    currentStep,
+    activeSteps,
+    currentLinks,
+    useGraphCanvas,
+    playbackSpeed,
+    topicTypeConfig,
+    currentStatusColorMap,
+  ]);
+  handleNextRef.current = handleNext;
+
   const handlePrev = () => setCurrentStep((prev) => Math.max(prev - 1, 0));
   const handleReset = () => {
     executeAction("reset", { hasTailMode, mode: viewMode, isDirected });
@@ -908,6 +1011,9 @@ function TutorialContent() {
     handleReset,
     setPlaybackSpeed,
     handleStepChange,
+    graphCanvasRef,
+    d3CanvasRef,
+    useGraphCanvas,
   };
 
   return (

--- a/frontend/src/pages/Tutorial/components/TopSection/TopSection.tsx
+++ b/frontend/src/pages/Tutorial/components/TopSection/TopSection.tsx
@@ -21,6 +21,8 @@ import type { AlgorithmViewMode } from '@/types/implementation';
 import { usePanelContext } from '@/pages/Tutorial/context/PanelContext';
 import { InspectorPanelInternal, type InspectorPanelInternalProps } from '@/pages/Tutorial/Tutorial';
 import type { BaseElement } from '@/modules/core/DataLogic/BaseElement';
+import type { D3CanvasRef } from '@/modules/core/Render/D3Canvas';
+import type { GraphCanvasRef } from '@/modules/core/Render/GraphCanvas';
 import styles from './TopSection.module.scss';
 
 interface CanvasPanelProps {
@@ -47,6 +49,10 @@ interface CanvasPanelProps {
   handleReset: () => void;
   setPlaybackSpeed: (speed: number) => void;
   handleStepChange: (step: number) => void;
+
+  graphCanvasRef: React.RefObject<GraphCanvasRef | null>;
+  d3CanvasRef: React.RefObject<D3CanvasRef | null>;
+  useGraphCanvas: boolean;
 }
 
 interface TopSectionProps {

--- a/frontend/src/types/canvasTypes.ts
+++ b/frontend/src/types/canvasTypes.ts
@@ -17,3 +17,13 @@ export interface BaseCanvasProps {
   allStepsElements?: BaseElement[][];
   disableAutoFit?: boolean;
 }
+
+export interface AnimatableCanvasRef {
+  animateLink: (
+    sourceId: string,
+    targetId: string,
+    toColor: string,
+    duration?: number,
+    onComplete?: () => void,
+  ) => void;
+}

--- a/frontend/src/types/implementation.ts
+++ b/frontend/src/types/implementation.ts
@@ -4,6 +4,18 @@ import type { StatusConfig } from "./statusConfig";
 import type { VisualizationActionHandler } from "@/modules/core/visualization/types";
 import type { RealWorldStory } from "./realWorldStory";
 
+/** 哪些 link.status 變化時要播放邊動畫（由演算法 config 選填） */
+export interface LinkAnimConfig {
+  /** 這些 status 觸發動畫並阻塞 step 推進 */
+  animateOn: string[];
+  /** 這些 status 直接換色（step 推進後 re-render 自動套用，不阻塞）；僅作為文件語義 */
+  directOn?: string[];
+}
+
+export const DEFAULT_LINK_ANIM_CONFIG: LinkAnimConfig = {
+  animateOn: [],
+};
+
 export type {
   PythonInput,
   PythonDemo,
@@ -115,6 +127,8 @@ export interface LevelImplementationConfig {
   defaultViewMode?: AlgorithmViewMode;
   /** 是否預設為有向圖（無 ActionBar toggle 時使用）。 */
   defaultIsDirected?: boolean;
+  /** 圖邊狀態變化時是否觸發 animateLink；未設定則使用 DEFAULT_LINK_ANIM_CONFIG */
+  linkAnimConfig?: LinkAnimConfig;
   renderActionBar?: (props: ActionBarProps) => ReactNode;
   /** 可選的 action 處理器（Strategy 模式），用於 useVisualizationLogic 薄殼委派 */
   actionHandler?: VisualizationActionHandler<any>;


### PR DESCRIPTION
# Feature
- Add `AnimatableCanvasRef` shared interface for `GraphCanvas` and `D3Canvas`,
  unifying `animateLink(sourceId, targetId, toColor, duration?, onComplete?)` API
- Add `LinkAnimConfig` type and `linkAnimConfig` field to `LevelImplementationConfig`,
  allowing each algorithm config to declare which link statuses trigger animation vs. direct color update
- Implement `animateLink` in `GraphCanvas` (link path + node circle, with reverse fallback)
  and `D3Canvas` (link path only, avoids D3Renderer flicker)
- `Tutorial.tsx` `handleNext` auto-triggers `activeCanvas.animateLink` based on `linkAnimConfig.animateOn`,
  with `isAnimatingRef` guard and auto-play support

# Refactor
- `D3Canvas`, `D3Renderer`, `GraphCanvas`: refactor link status update flow to support
  status-driven animation dispatch
- `Tutorial.tsx`: unify canvas ref access via `activeCanvas` (`graphCanvasRef` or `d3CanvasRef`)

# Fix
- `linksMap` bug in `GraphCanvas` D3 effect: undirected graph now preserves defined status
  over undefined, preventing stale link color
- Update link status configs in `BinarySearchTree`, `BinaryTree`, `Graph`, `BFS`, `DFS`,
  `dijkstra`, `topologicalSort` to align with new `animateOn` / `directOn` semantics

# 破壞性改動
- 無（`linkAnimConfig` 為選填，未設定自動 fallback 至 `DEFAULT_LINK_ANIM_CONFIG`）
