### PR TITLE
Fix/Chore: harden env-var validation, add API URL guard, and deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy to Lab Server
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via GCP Jump Host
+        run: |
+          # Setup SSH Directory
+          mkdir -p ~/.ssh
+          echo "${{ secrets.GCP_KEY }}" > ~/.ssh/gcp_key
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/gcp_key ~/.ssh/deploy_key
+
+          # Configure SSH for ProxyJump
+          cat >> ~/.ssh/config << EOF
+          Host gcp
+            HostName ${{ secrets.GCP_HOST }}
+            User ${{ secrets.GCP_USER }}
+            IdentityFile ~/.ssh/gcp_key
+            StrictHostKeyChecking no
+
+          Host lab
+            HostName localhost
+            Port 22
+            User ${{ secrets.LAB_USER }}
+            IdentityFile ~/.ssh/deploy_key
+            ProxyJump gcp
+            StrictHostKeyChecking no
+          EOF
+
+          # Execute Deployment Commands on Server
+          ssh lab << 'ENDSSH'
+            cd ~/projects/CodePulse
+            git pull origin main
+            source backend/venv/bin/activate
+            pip install -r backend/requirements.prod.txt
+            sudo systemctl restart codepulse-backend
+            echo "Deployment Successful"
+          ENDSSH

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -24,4 +24,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
 # --timeout: 請求超時時間
 # --access-logfile: 存取日誌
 # --error-logfile: 錯誤日誌
-CMD gunicorn --workers=4 --bind=0.0.0.0:$PORT --timeout=120 --access-logfile=- --error-logfile=- "app:app"
+CMD gunicorn --workers=1 --threads=4 --bind=0.0.0.0:$PORT --timeout=120 --access-logfile=- --error-logfile=- "app:app"

--- a/backend/config.py
+++ b/backend/config.py
@@ -5,10 +5,6 @@ load_dotenv(os.path.join(os.path.dirname(__file__), '..', '.env'))
 
 class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'dev-secret-key-do-not-use-in-production'
-
-    @classmethod
-    def init_app(cls, app):
-        pass
     DEBUG = os.environ.get('DEBUG', 'False').lower() == 'true'
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
@@ -25,6 +21,10 @@ class Config:
     CLOUDINARY_CLOUD_NAME = os.environ.get('CLOUDINARY_CLOUD_NAME')
     CLOUDINARY_API_KEY = os.environ.get('CLOUDINARY_API_KEY')
     CLOUDINARY_API_SECRET = os.environ.get('CLOUDINARY_API_SECRET')
+
+    @classmethod
+    def init_app(cls, app):
+        pass
 
 class DevelopmentConfig(Config):
     DEBUG = True
@@ -49,10 +49,16 @@ class ProductionConfig(Config):
     @classmethod
     def init_app(cls, app):
         super().init_app(app)
-        if not cls.SECRET_KEY:
-            raise ValueError('SECRET_KEY environment variable must be set in production')
-        if not cls.CORS_ORIGINS:
-            raise ValueError('ALLOWED_ORIGINS environment variable must be set in production')
+        required = {
+            'SECRET_KEY': cls.SECRET_KEY,
+            'ALLOWED_ORIGINS': cls.CORS_ORIGINS,
+            'DATABASE_URL': os.environ.get('DATABASE_URL'),
+            'GOOGLE_CLIENT_ID': cls.GOOGLE_CLIENT_ID,
+            'GOOGLE_CLIENT_SECRET': cls.GOOGLE_CLIENT_SECRET,
+        }
+        missing = [k for k, v in required.items() if not v]
+        if missing:
+            raise ValueError(f'Missing required environment variables: {", ".join(missing)}')
 
 class TestingConfig(Config):
     TESTING = True

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request, make_response, g
+from flask import Blueprint, jsonify, request, make_response, g, current_app
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 import uuid
@@ -47,7 +47,7 @@ def _user_to_dict(user):
     }
 
 
-# ── Register ─────────────────────────────────────────────────────────────────
+# Register
 
 @auth_bp.route('/register', methods=['POST'])
 def register():
@@ -94,7 +94,7 @@ def register():
     return jsonify({'success': True, 'message': '驗證碼已寄出，請檢查您的信箱'}), 200
 
 
-# ── Login ────────────────────────────────────────────────────────────────────
+# Login
 
 @auth_bp.route('/login', methods=['POST'])
 @limiter.limit("10 per minute; 50 per hour")
@@ -167,7 +167,7 @@ def login():
     return resp
 
 
-# ── Logout ───────────────────────────────────────────────────────────────────
+# Logout
 
 @auth_bp.route('/logout', methods=['POST'])
 def logout():
@@ -188,7 +188,7 @@ def logout():
     return resp
 
 
-# ── Me ───────────────────────────────────────────────────────────────────────
+# Me
 
 @auth_bp.route('/me', methods=['GET'])
 @login_required
@@ -199,7 +199,7 @@ def get_current_user():
     return jsonify({'success': True, 'user': _user_to_dict(user)}), 200
 
 
-# ── Verify Email ─────────────────────────────────────────────────────────────
+# Verify Email
 
 @auth_bp.route('/verify-email', methods=['POST'])
 def verify_email():
@@ -277,7 +277,7 @@ def verify_email():
     return resp
 
 
-# ── Complete Setup (Google Onboarding) ───────────────────────────────────────
+# Complete Setup (Google Onboarding)
 
 RESERVED_USERNAMES = {'admin', 'root', 'system', 'codepulse', 'support', 'moderator', 'staff'}
 USERNAME_RE = __import__('re').compile(r'^[a-zA-Z0-9_]{3,15}$')
@@ -356,7 +356,7 @@ def complete_setup():
     return resp
 
 
-# ── Check Username Availability ───────────────────────────────────────────────
+# Check Username Availability
 
 @auth_bp.route('/check-username', methods=['GET'])
 def check_username():
@@ -373,7 +373,7 @@ def check_username():
     return jsonify({'available': taken is None}), 200
 
 
-# ── Onboarding Info ──────────────────────────────────────────────────────────
+# Onboarding Info
 
 @auth_bp.route('/onboarding-info', methods=['GET'])
 def onboarding_info():
@@ -397,7 +397,7 @@ def onboarding_info():
     }), 200
 
 
-# ── Resend Verification ───────────────────────────────────────────────────────
+# Resend Verification
 
 RESEND_COOLDOWN_SECONDS = 60
 RESEND_DAILY_LIMIT = 5
@@ -490,7 +490,7 @@ def resend_verification():
     }), 200
 
 
-# ── Refresh ──────────────────────────────────────────────────────────────────
+# Refresh
 
 @auth_bp.route('/refresh', methods=['POST'])
 def refresh_token():
@@ -557,7 +557,7 @@ def refresh_token():
     return resp
 
 
-# ── Status ───────────────────────────────────────────────────────────────────
+# Status
 
 @auth_bp.route('/status', methods=['GET'])
 def get_user_status():
@@ -644,7 +644,7 @@ def get_user_status():
     }), 200
 
 
-# ── Forgot Password ───────────────────────────────────────────────────────────
+# Forgot Password
 
 FORGOT_COOLDOWN_SECONDS = 60
 FORGOT_DAILY_LIMIT = 5
@@ -721,7 +721,7 @@ def forgot_password():
     return jsonify({'success': True, 'message': '若此 Email 已註冊，驗證碼已寄出'}), 200
 
 
-# ── Reset Password ────────────────────────────────────────────────────────────
+# Reset Password
 
 import re as _re
 _CODE_RE = _re.compile(r'^[A-Z0-9]{6}$')

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,8 +1,10 @@
-// API base URL:
-// - dev：空字串走 Vite proxy
-// - prod：用 VITE_API_URL 或 VITE_BACKEND_URL（指向後端域名）
+// dev：空字串走 Vite proxy；prod：需設 VITE_API_URL 或 VITE_BACKEND_URL（指向後端域名）
 export const API_BASE_URL =
   import.meta.env.VITE_API_URL || import.meta.env.VITE_BACKEND_URL || "";
+
+if (import.meta.env.PROD && !API_BASE_URL) {
+  console.error("[api] VITE_API_URL is not set — all API calls will fail");
+}
 
 // API 基本配置類型
 interface ApiConfig {


### PR DESCRIPTION
## Summary

- Production startup now validates all required environment variables
  at once and fails with a clear, unified error message
- Frontend warns immediately in the console when `VITE_API_URL` is
  missing in a production build, surfacing misconfigurations early
- Minor style cleanup in auth.py section comments

---

## Features

### Automated deployment pipeline

- Added `.github/workflows/deploy.yml` triggered on push to `main`
- Connects to lab server via GCP jump host (ProxyJump) using SSH secrets
- Runs `git pull`, `pip install`, and `systemctl restart` on the target server
- Secrets required: `GCP_KEY`, `GCP_HOST`, `GCP_USER`, `DEPLOY_KEY`, `LAB_USER`

---

## Fixes

### Incomplete production env-var validation

- **Problem:** `ProductionConfig.init_app` only checked `SECRET_KEY`
  and `ALLOWED_ORIGINS`; missing `DATABASE_URL` or Google OAuth
  credentials would cause silent or late failures
- **Impact:** Misconfigured deployments could boot successfully then
  crash at runtime during the first DB or OAuth call
- **Fix:** Collect all required vars into a dict, gather every missing
  key, and raise a single descriptive `ValueError` listing them all

### Silent API failure on missing VITE_API_URL in production

- **Problem:** If `VITE_API_URL` was not set, the frontend would call
  relative paths in production, silently hitting the wrong host
- **Impact:** All API calls would fail with no actionable error visible
- **Fix:** Added a `console.error` guard that fires at module load time
  in `PROD` builds when the base URL is empty

### Prevent task loss across workers by using single-process Gunicorn

- Reduce Gunicorn workers from 4 to 1 and enable threads
- Ensure in-memory task_queue is shared within the same process
- Fix /api/analyze/status/<task_id> returning 404 in production
- Align production behavior with single-process dev environment

---

## Backend Changes

- `ProductionConfig.init_app` validates 5 required env vars in one pass
- Moved `Config.init_app` stub below field declarations for readability
- Cleaned up `──` ASCII-art section separators in `auth.py` to plain comments

## Frontend Changes

- `api.ts`: added production-only guard that logs an error if no API
  base URL is configured

---

## Impact

- Misconfigured deployments fail fast at startup with an actionable
  message instead of crashing mid-request
- Easier to debug production environment issues
- No behavior changes for correctly configured environments
