### PR TITLE
Fix: use dedicated refresh endpoint and sync auth state on token renewal

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -56,18 +56,20 @@ class ApiService {
     // 1. 執行第一次請求
     let response = await this.executeFetch(url, options);
 
-    // 2. 如果 401 且不是在請求 status 本身時（避免無限循環）
-    if (response.status === 401 && endpoint !== "/api/auth/status") {
+    // 2. 如果 401 且不是在請求 refresh 本身時（避免無限循環）
+    if (response.status === 401 && endpoint !== "/api/auth/refresh") {
       try {
-        // 嘗試呼叫 status 接口讓後端更新 Token
-        await this.executeFetch(`${this.config.baseURL}/api/auth/status`, {
-          credentials: "include",
-        });
+        const refreshResp = await this.executeFetch(
+          `${this.config.baseURL}/api/auth/refresh`,
+          { method: "POST", credentials: "include" },
+        );
 
-        // 3. 重新執行原始請求
-        response = await this.executeFetch(url, options);
+        if (refreshResp.ok) {
+          window.dispatchEvent(new Event("auth:refreshed"));
+          // 3. 重新執行原始請求
+          response = await this.executeFetch(url, options);
+        }
       } catch (e) {
-        // 刷新失敗，維持原本的 401 狀態
         console.warn("Token refresh failed", e);
       }
     }

--- a/frontend/src/shared/contexts/AuthContext.tsx
+++ b/frontend/src/shared/contexts/AuthContext.tsx
@@ -104,6 +104,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     checkAuthStatus();
   }, [checkAuthStatus]);
 
+  useEffect(() => {
+    const handler = () => checkAuthStatus();
+    window.addEventListener("auth:refreshed", handler);
+    return () => window.removeEventListener("auth:refreshed", handler);
+  }, [checkAuthStatus]);
+
   const value: AuthContextType = {
     isAuthenticated,
     user,


### PR DESCRIPTION
## Summary
- Replace incorrect use of `/api/auth/status` with `POST /api/auth/refresh` for token renewal
- Only retry the original request when refresh actually succeeds (`refreshResp.ok`)
- Dispatch `auth:refreshed` event and listen in `AuthContext` to re-sync user state after refresh

## Test plan
- [ ] Log in, let access token expire, then make an authenticated request — should auto-refresh and succeed
- [ ] Confirm auth state stays in sync (user info not lost after silent refresh)
- [ ] Confirm 401 on `/api/auth/refresh` itself does not cause an infinite loop
