### PR TITLE
Fix: exclude portal levels from learning progress counts

### DIFF
--- a/frontend/src/pages/LearningDashboard/LearningDashboard.tsx
+++ b/frontend/src/pages/LearningDashboard/LearningDashboard.tsx
@@ -34,6 +34,7 @@ import {
   calculateDisplayStatus,
   calculateOverallProgress,
   calculateCategoryProgress,
+  isProgressTrackableLevel,
   startLevel,
 } from "@/services/ProgressService";
 import {
@@ -94,7 +95,13 @@ function LearningDashboardInner() {
 
   // 計算每個 Category 的 Level 數量
   const levelCounts = Object.fromEntries(
-    categories.map((c) => [c.id, allLevels.filter((l) => l.category === c.id).length - 1])
+    categories.map((c) => [
+      c.id,
+      allLevels.filter(
+        (level) =>
+          level.category === c.id && isProgressTrackableLevel(level),
+      ).length,
+    ]),
   ) as Partial<Record<CategoryType, number>>;
 
   // 建立分類顏色對照表

--- a/frontend/src/services/ProgressService.ts
+++ b/frontend/src/services/ProgressService.ts
@@ -222,6 +222,10 @@ export function calculateDisplayStatus(
 
 // ==================== 進度統計 ====================
 
+export function isProgressTrackableLevel(level: Level): boolean {
+  return level.pathMetadata?.pathType !== "portal";
+}
+
 /**
  * 計算總體進度統計
  */
@@ -235,13 +239,21 @@ export function calculateOverallProgress(
   earnedStars: number;
   completionRate: number;
 } {
-  const totalLevels = allLevels.length;
-  const completedLevels = Object.values(userProgress.levels).filter(
-    (progress) => progress.status === "completed",
+  const progressTrackableLevels = allLevels.filter(isProgressTrackableLevel);
+  const progressTrackableLevelIds = new Set(
+    progressTrackableLevels.map((level) => level.id),
+  );
+
+  const totalLevels = progressTrackableLevels.length;
+  const completedLevels = progressTrackableLevels.filter(
+    (level) => userProgress.levels[level.id]?.status === "completed",
   ).length;
   const totalStars = totalLevels * 3;
   const earnedStars = Object.values(userProgress.levels).reduce(
-    (sum, progress) => sum + progress.stars,
+    (sum, progress) =>
+      progressTrackableLevelIds.has(progress.levelId)
+        ? sum + progress.stars
+        : sum,
     0,
   );
   const completionRate =
@@ -263,7 +275,7 @@ export function calculateCategoryProgress(
   allLevels: Level[],
   userProgress: UserProgress,
 ): Record<CategoryType, CategoryProgressInfo> {
-  return allLevels.reduce(
+  return allLevels.filter(isProgressTrackableLevel).reduce(
     (acc, level) => {
       const category = level.category;
 


### PR DESCRIPTION
# Summary

This PR updates Learning Dashboard progress calculations so portal-type levels are excluded from trackable learning progress. It fixes inflated level counts, completion totals, and earned star calculations by centralizing the definition of progress-trackable levels in `ProgressService`.

It also updates the frontend Docker Node base image from Node 20 to Node 22.

## Fixes

### Portal Levels Included in Progress Metrics

- **Problem:** Portal levels were counted as normal learning levels in dashboard totals and category counts.
- **Impact:** Users could see inaccurate level counts, completion percentages, and earned star totals.
- **Fix:** Add a shared `isProgressTrackableLevel` helper and apply it to overall progress, category progress, earned stars, and dashboard category level counts.

## Frontend Changes

- Update `LearningDashboard` category level counts to count only progress-trackable levels.
- Reuse the same progress filtering rule from `ProgressService` to keep dashboard UI and progress statistics consistent.

## Infrastructure / Deployment

- Update the frontend Docker development image and commented production build image from Node 20 to Node 22.
- Normalize the Dockerfile trailing newline.

## Impact

This PR makes learning progress metrics more accurate and maintainable by ensuring portal/navigation levels do not affect user progress calculations. Centralizing the trackable-level rule also reduces the chance of future dashboard and service-layer count mismatches.