### PR TITLE
Fix: wrap analysis task execution in Flask app context

### DIFF
--- a/backend/services/analysis_runner.py
+++ b/backend/services/analysis_runner.py
@@ -136,17 +136,19 @@ def run_analysis_task(
     save_history: bool | None = None,
 ) -> dict:
     """Celery task: analysis main flow. task_id = self.request.id."""
+    from app import app as flask_app
     task_id = self.request.id
     if save_history is None:
         headers = getattr(self.request, "headers", None) or {}
         save_history = headers.get("save_history", True) is not False
-    return _run_analysis(
-        task_id,
-        code,
-        wrapped_code,
-        user_id=user_id,
-        save_history=save_history,
-    )
+    with flask_app.app_context():
+        return _run_analysis(
+            task_id,
+            code,
+            wrapped_code,
+            user_id=user_id,
+            save_history=save_history,
+        )
 
 
 def _run_analysis(

--- a/backend/services/task_queue_memory.py
+++ b/backend/services/task_queue_memory.py
@@ -115,11 +115,13 @@ class TaskQueue:
                 break
 
     def _run(self, task_id: str, fn, args: tuple, kwargs: dict) -> None:
+        from app import app as flask_app
         with self._lock:
             if task_id in self._tasks:
                 self._tasks[task_id]["status"] = STATUS_RUNNING
         try:
-            result = fn(task_id, *args, **kwargs)
+            with flask_app.app_context():
+                result = fn(task_id, *args, **kwargs)
             with self._lock:
                 if task_id in self._tasks:
                     self._tasks[task_id]["status"] = STATUS_COMPLETED


### PR DESCRIPTION
- Inject app_context into TaskQueue._run (in-process thread pool path)
- Inject app_context into run_analysis_task (Celery worker path)
- Resolves RuntimeError "Working outside of application context" when _save_history attempts DB access via Flask-SQLAlchemy