### PR TITLE
Feature/tutorial progressive disclosure

### DIFF
--- a/frontend/src/modules/core/components/CodeEditor/CodeEditor.tsx
+++ b/frontend/src/modules/core/components/CodeEditor/CodeEditor.tsx
@@ -80,6 +80,8 @@ export interface CodeEditorHandle {
   setErrorMarker: (lineno: number, message: string) => void;
   /** 清除語法錯誤標記 */
   clearErrorMarker: () => void;
+  /** 回傳渲染當前 code 所需的像素寬度（最長行 × 字元寬 + gutter）。wordWrap:on 時 getContentWidth() 不可靠，改用 model 行長計算。 */
+  getContentWidth: () => number;
 }
 
 // ==================== 語言對應表 ====================
@@ -489,6 +491,19 @@ const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>((props, ref) =>
       const model = editor.getModel();
       if (!model) return;
       monacoInstance.editor.setModelMarkers(model, "analyzeError", []);
+    },
+    getContentWidth: () => {
+      const editor = mode === 'split' ? topEditorRef.current : editorRef.current;
+      if (!editor) return 0;
+      const model = editor.getModel();
+      if (!model) return 0;
+      let maxLen = 0;
+      for (let i = 1; i <= model.getLineCount(); i++) {
+        maxLen = Math.max(maxLen, model.getLineLength(i));
+      }
+      const fontInfo = editor.getOption(monaco.editor.EditorOption.fontInfo);
+      const charWidth = fontInfo.typicalHalfwidthCharacterWidth;
+      return Math.ceil(maxLen * charWidth) + 50;
     },
   }));
 

--- a/frontend/src/pages/Tutorial/Tutorial.tsx
+++ b/frontend/src/pages/Tutorial/Tutorial.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/types/statusConfig";
 import { useTranslation } from "react-i18next";
 import type { StepDescription } from "@/types";
+import type { CodeEditorHandle } from "@/modules/core/components/CodeEditor/CodeEditor";
 
 function renderDescription(
   desc: string | StepDescription | undefined,
@@ -201,19 +202,21 @@ const CanvasPanel = ({
             <div className={styles.stepDescription}>
               {renderDescription(currentStepData?.description, t)}
             </div>
-            <ControlBar
-              isPlaying={isPlaying}
-              currentStep={currentStep}
-              totalSteps={activeStepsLength}
-              playbackSpeed={playbackSpeed}
-              onPlay={handlePlay}
-              onPause={handlePause}
-              onNext={handleNext}
-              onPrev={handlePrev}
-              onReset={handleResetStep}
-              onSpeedChange={setPlaybackSpeed}
-              onStepChange={handleStepChange}
-            />
+            <div data-tour="control-bar">
+              <ControlBar
+                isPlaying={isPlaying}
+                currentStep={currentStep}
+                totalSteps={activeStepsLength}
+                playbackSpeed={playbackSpeed}
+                onPlay={handlePlay}
+                onPause={handlePause}
+                onNext={handleNext}
+                onPrev={handlePrev}
+                onReset={handleResetStep}
+                onSpeedChange={setPlaybackSpeed}
+                onStepChange={handleStepChange}
+              />
+            </div>
           </>
         )}
       </div>
@@ -421,6 +424,7 @@ function TutorialContent() {
   const isAnimatingRef = useRef(false);
   const isPlayingRef = useRef(false);
   const handleNextRef = useRef<() => void>(() => {});
+  const codeEditorRef = useRef<CodeEditorHandle>(null);
 
   // Collapse states (使用 context 的 collapsed state)
   const isLeftPanelCollapsed = collapsedPanels.has("codeEditor");
@@ -430,10 +434,18 @@ function TutorialContent() {
 
   // Feature Tour state
   const [showFeatureTour, setShowFeatureTour] = useState(true);
-  const handleSkipFeatureTour = () => setShowFeatureTour(false);
+  const handleSkipFeatureTour = () => {
+    setShowFeatureTour(false);
+    if (!hasStartedAnimation) {
+      setTimeout(() => leftPanelRef.current?.collapse(), 0);
+    }
+  };
   const handleCompleteFeatureTour = () => {
     setShowFeatureTour(false);
     setIsKnowledgeStationOpen(true);
+    if (!hasStartedAnimation) {
+      setTimeout(() => leftPanelRef.current?.collapse(), 0);
+    }
   };
 
   // Inspector Tab state
@@ -568,11 +580,11 @@ function TutorialContent() {
     activeSteps.length > 1 &&
     currentStep === activeSteps.length - 1;
 
-  const showControls = hasStartedAnimation;
+  const showControls = hasStartedAnimation || showFeatureTour;
 
   const disabledTabs = useMemo((): Set<string> => {
     if (!hasStartedAnimation) return new Set(["variableStatus"]);
-    if (isAtLastStep) return new Set(["variableStatus"]);
+    if (isAtLastStep) return new Set();
     return new Set(["actionBar"]);
   }, [hasStartedAnimation, isAtLastStep]);
 
@@ -668,18 +680,41 @@ function TutorialContent() {
     return () => clearInterval(interval);
   }, [isPlaying, playbackSpeed]);
 
-  // 5. Progressive disclosure：偵測首次開始播放
+  // 5. FeatureTour：開啟時展開 CodeEditor 讓導覽步驟可見；關閉由 handler 負責收起
+  useEffect(() => {
+    if (showFeatureTour && !hasStartedAnimation) {
+      setTimeout(() => {
+        if (leftPanelRef.current?.isCollapsed()) {
+          leftPanelRef.current.expand();
+        }
+      }, 0);
+    }
+  }, [showFeatureTour]);
+
+  // 6. Progressive disclosure：偵測首次開始播放
   useEffect(() => {
     if (isPlaying && !hasStartedAnimation) {
       setHasStartedAnimation(true);
     }
   }, [isPlaying, hasStartedAnimation]);
 
-  // 6. Progressive disclosure：首次開始後，時序展開 CodeEditor 並切換 tab（只觸發一次）
+  // 7. Progressive disclosure：首次開始後，時序展開 CodeEditor（動態寬度）並切換 tab（只觸發一次）
   useEffect(() => {
     if (!hasStartedAnimation) return;
     const timer = setTimeout(() => {
-      leftPanelRef.current?.expand();
+      if (leftPanelRef.current?.isCollapsed()) {
+        const contentPx = codeEditorRef.current?.getContentWidth() ?? 0;
+        const rightPanelPx = rightPanelRef.current?.getSize().inPixels ?? 0;
+        if (contentPx > 0 && rightPanelPx > 0) {
+          const targetPercent = Math.min(
+            panelSizes.codeEditor,
+            (contentPx / rightPanelPx) * 100,
+          );
+          leftPanelRef.current?.resize(targetPercent);
+        } else {
+          leftPanelRef.current?.expand();
+        }
+      }
       setActiveInspectorTab("variableStatus");
     }, 400);
     return () => clearTimeout(timer);
@@ -1248,6 +1283,7 @@ function TutorialContent() {
         handleModeToggle={handleModeToggle}
         currentCodeConfig={currentCodeConfig}
         highlightLines={highlightLines}
+        codeEditorRef={codeEditorRef}
       />
 
       {/* Knowledge Station Dialog */}

--- a/frontend/src/pages/Tutorial/Tutorial.tsx
+++ b/frontend/src/pages/Tutorial/Tutorial.tsx
@@ -708,7 +708,7 @@ function TutorialContent() {
             panelSizes.codeEditor,
             (contentPx / rightPanelPx) * 100,
           );
-          leftPanelRef.current?.resize(targetPercent);
+          leftPanelRef.current?.resize(`${targetPercent}%`);
         } else {
           leftPanelRef.current?.expand();
         }

--- a/frontend/src/pages/Tutorial/Tutorial.tsx
+++ b/frontend/src/pages/Tutorial/Tutorial.tsx
@@ -452,7 +452,6 @@ function TutorialContent() {
   const [activeInspectorTab, setActiveInspectorTab] =
     useState<string>("actionBar");
   const [hasStartedAnimation, setHasStartedAnimation] = useState(false);
-  const prevIsAtLastStepRef = useRef(false);
 
   // RWD: 检测屏幕宽度
   const [isMobile, setIsMobile] = useState(window.innerWidth < 1024);
@@ -649,7 +648,6 @@ function TutorialContent() {
       setIsDirected(topicTypeConfig.defaultIsDirected ?? false);
       setHasStartedAnimation(false);
       setActiveInspectorTab("actionBar");
-      prevIsAtLastStepRef.current = false;
       // setTimeout 讓 collapse 在當前 render 完成後執行，避免 react-resizable-panels 尚未完成 remount
       setTimeout(() => leftPanelRef.current?.collapse(), 0);
     }
@@ -720,18 +718,6 @@ function TutorialContent() {
     return () => clearTimeout(timer);
   }, [hasStartedAnimation]);
 
-  // 7. Progressive disclosure：偵測 PLAYING ↔ ENDED 轉換，切換 tab
-  useEffect(() => {
-    if (!hasStartedAnimation) return;
-    const atLast =
-      activeSteps.length > 1 && currentStep === activeSteps.length - 1;
-    if (atLast && !prevIsAtLastStepRef.current) {
-      setActiveInspectorTab("actionBar");
-    } else if (!atLast && prevIsAtLastStepRef.current) {
-      setActiveInspectorTab("variableStatus");
-    }
-    prevIsAtLastStepRef.current = atLast;
-  }, [currentStep, activeSteps.length, hasStartedAnimation]);
 
   const allStepsElements = useMemo(() => {
     return activeSteps.map((step) => step?.elements ?? []);

--- a/frontend/src/pages/Tutorial/Tutorial.tsx
+++ b/frontend/src/pages/Tutorial/Tutorial.tsx
@@ -91,6 +91,7 @@ interface CanvasPanelProps {
   graphCanvasRef: React.RefObject<GraphCanvasRef | null>;
   d3CanvasRef: React.RefObject<D3CanvasRef | null>;
   useGraphCanvas: boolean;
+  showControls: boolean;
 }
 
 const CanvasPanel = ({
@@ -121,6 +122,7 @@ const CanvasPanel = ({
   graphCanvasRef,
   d3CanvasRef,
   useGraphCanvas,
+  showControls,
 }: CanvasPanelProps) => {
   const { t } = useTranslation(topicTypeConfig?.i18nNamespace ?? "animation");
   const {
@@ -194,24 +196,26 @@ const CanvasPanel = ({
             />
           )}
         </div>
-        <div className={styles.stepDescription}>
-          {renderDescription(currentStepData?.description, t)}
-        </div>
-
-        {/* ControlBar 直接渲染,無 PanelHeader */}
-        <ControlBar
-          isPlaying={isPlaying}
-          currentStep={currentStep}
-          totalSteps={activeStepsLength}
-          playbackSpeed={playbackSpeed}
-          onPlay={handlePlay}
-          onPause={handlePause}
-          onNext={handleNext}
-          onPrev={handlePrev}
-          onReset={handleResetStep}
-          onSpeedChange={setPlaybackSpeed}
-          onStepChange={handleStepChange}
-        />
+        {showControls && (
+          <>
+            <div className={styles.stepDescription}>
+              {renderDescription(currentStepData?.description, t)}
+            </div>
+            <ControlBar
+              isPlaying={isPlaying}
+              currentStep={currentStep}
+              totalSteps={activeStepsLength}
+              playbackSpeed={playbackSpeed}
+              onPlay={handlePlay}
+              onPause={handlePause}
+              onNext={handleNext}
+              onPrev={handlePrev}
+              onReset={handleResetStep}
+              onSpeedChange={setPlaybackSpeed}
+              onStepChange={handleStepChange}
+            />
+          </>
+        )}
       </div>
     </Panel>
   );
@@ -246,6 +250,7 @@ export interface InspectorPanelInternalProps {
   handleViewModeChange: (mode: AlgorithmViewMode) => void;
   currentData: any;
   currentStepData: any;
+  disabledTabs: Set<string>;
 }
 
 export const InspectorPanelInternal = ({
@@ -276,6 +281,7 @@ export const InspectorPanelInternal = ({
   handleViewModeChange,
   currentData,
   currentStepData,
+  disabledTabs,
 }: InspectorPanelInternalProps) => {
   const { activePanels } = usePanelContext();
 
@@ -288,8 +294,9 @@ export const InspectorPanelInternal = ({
         key: config.id,
         label: config.title,
         icon: config.icon,
+        disabled: disabledTabs.has(config.id),
       }));
-  }, [activePanels]);
+  }, [activePanels, disabledTabs]);
 
   // 拖拽邏輯
   const {
@@ -432,6 +439,8 @@ function TutorialContent() {
   // Inspector Tab state
   const [activeInspectorTab, setActiveInspectorTab] =
     useState<string>("actionBar");
+  const [hasStartedAnimation, setHasStartedAnimation] = useState(false);
+  const prevIsAtLastStepRef = useRef(false);
 
   // RWD: 检测屏幕宽度
   const [isMobile, setIsMobile] = useState(window.innerWidth < 1024);
@@ -554,6 +563,19 @@ function TutorialContent() {
       currentStep > 0 &&
       currentStep < activeSteps.length - 1);
 
+  const isAtLastStep =
+    hasStartedAnimation &&
+    activeSteps.length > 1 &&
+    currentStep === activeSteps.length - 1;
+
+  const showControls = hasStartedAnimation;
+
+  const disabledTabs = useMemo((): Set<string> => {
+    if (!hasStartedAnimation) return new Set(["variableStatus"]);
+    if (isAtLastStep) return new Set(["variableStatus"]);
+    return new Set(["actionBar"]);
+  }, [hasStartedAnimation, isAtLastStep]);
+
   const maxNodes = topicTypeConfig?.maxNodes;
   const randomCountRef = useRef(5);
 
@@ -613,6 +635,11 @@ function TutorialContent() {
       setIsPlaying(false);
       setViewMode(topicTypeConfig.defaultViewMode ?? "");
       setIsDirected(topicTypeConfig.defaultIsDirected ?? false);
+      setHasStartedAnimation(false);
+      setActiveInspectorTab("actionBar");
+      prevIsAtLastStepRef.current = false;
+      // setTimeout 讓 collapse 在當前 render 完成後執行，避免 react-resizable-panels 尚未完成 remount
+      setTimeout(() => leftPanelRef.current?.collapse(), 0);
     }
   }, [topicTypeConfig]);
 
@@ -640,6 +667,36 @@ function TutorialContent() {
     }, 1000 / playbackSpeed);
     return () => clearInterval(interval);
   }, [isPlaying, playbackSpeed]);
+
+  // 5. Progressive disclosure：偵測首次開始播放
+  useEffect(() => {
+    if (isPlaying && !hasStartedAnimation) {
+      setHasStartedAnimation(true);
+    }
+  }, [isPlaying, hasStartedAnimation]);
+
+  // 6. Progressive disclosure：首次開始後，時序展開 CodeEditor 並切換 tab（只觸發一次）
+  useEffect(() => {
+    if (!hasStartedAnimation) return;
+    const timer = setTimeout(() => {
+      leftPanelRef.current?.expand();
+      setActiveInspectorTab("variableStatus");
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [hasStartedAnimation]);
+
+  // 7. Progressive disclosure：偵測 PLAYING ↔ ENDED 轉換，切換 tab
+  useEffect(() => {
+    if (!hasStartedAnimation) return;
+    const atLast =
+      activeSteps.length > 1 && currentStep === activeSteps.length - 1;
+    if (atLast && !prevIsAtLastStepRef.current) {
+      setActiveInspectorTab("actionBar");
+    } else if (!atLast && prevIsAtLastStepRef.current) {
+      setActiveInspectorTab("variableStatus");
+    }
+    prevIsAtLastStepRef.current = atLast;
+  }, [currentStep, activeSteps.length, hasStartedAnimation]);
 
   const allStepsElements = useMemo(() => {
     return activeSteps.map((step) => step?.elements ?? []);
@@ -1088,6 +1145,7 @@ function TutorialContent() {
     handleViewModeChange,
     currentData: logic.data,
     currentStepData,
+    disabledTabs,
   };
 
   const breadcrumbItems: BreadcrumbItem[] = [
@@ -1127,6 +1185,7 @@ function TutorialContent() {
     graphCanvasRef,
     d3CanvasRef,
     useGraphCanvas,
+    showControls,
   };
 
   return (

--- a/frontend/src/pages/Tutorial/Tutorial.tsx
+++ b/frontend/src/pages/Tutorial/Tutorial.tsx
@@ -1059,6 +1059,7 @@ function TutorialContent() {
   const handleResetStep = () => {
     setCurrentStep(0);
     setIsPlaying(false);
+    setHasStartedAnimation(false);
   };
   const handleStepChange = (step: number) => {
     setCurrentStep(step);

--- a/frontend/src/pages/Tutorial/components/TopSection/TopSection.tsx
+++ b/frontend/src/pages/Tutorial/components/TopSection/TopSection.tsx
@@ -54,6 +54,7 @@ interface CanvasPanelProps {
   graphCanvasRef: React.RefObject<GraphCanvasRef | null>;
   d3CanvasRef: React.RefObject<D3CanvasRef | null>;
   useGraphCanvas: boolean;
+  showControls: boolean;
 }
 
 interface TopSectionProps {

--- a/frontend/src/pages/Tutorial/components/TopSection/TopSection.tsx
+++ b/frontend/src/pages/Tutorial/components/TopSection/TopSection.tsx
@@ -20,6 +20,7 @@ const CodeEditor = lazy(() => import('@/modules/core/components/CodeEditor/CodeE
 import type { AlgorithmViewMode } from '@/types/implementation';
 import { usePanelContext } from '@/pages/Tutorial/context/PanelContext';
 import { InspectorPanelInternal, type InspectorPanelInternalProps } from '@/pages/Tutorial/Tutorial';
+import type { CodeEditorHandle } from '@/modules/core/components/CodeEditor/CodeEditor';
 import type { BaseElement } from '@/modules/core/DataLogic/BaseElement';
 import type { D3CanvasRef } from '@/modules/core/Render/D3Canvas';
 import type { GraphCanvasRef } from '@/modules/core/Render/GraphCanvas';
@@ -94,6 +95,7 @@ interface TopSectionProps {
   handleModeToggle: (mode: "pseudo" | "python") => void;
   currentCodeConfig: any;
   highlightLines: number[];
+  codeEditorRef?: React.RefObject<CodeEditorHandle | null>;
 }
 
 export function TopSection(props: TopSectionProps) {
@@ -117,6 +119,7 @@ export function TopSection(props: TopSectionProps) {
     handleModeToggle,
     currentCodeConfig,
     highlightLines,
+    codeEditorRef,
   } = props;
 
   const { panelSizes, setCollapsed } = usePanelContext();
@@ -201,6 +204,7 @@ export function TopSection(props: TopSectionProps) {
                     <div className={styles.pseudoCodeEditor}>
                       <Suspense fallback={null}>
                         <CodeEditor
+                          ref={codeEditorRef}
                           key={`editor-${mainPanelOrder.join("-")}`}
                           mode="single"
                           language="python"
@@ -379,6 +383,7 @@ export function TopSection(props: TopSectionProps) {
                     <div className={styles.pseudoCodeEditor}>
                       <Suspense fallback={null}>
                         <CodeEditor
+                          ref={codeEditorRef}
                           key={`editor-${mainPanelOrder.join("-")}`}
                           mode="single"
                           language="python"

--- a/frontend/src/pages/Tutorial/context/PanelContext.tsx
+++ b/frontend/src/pages/Tutorial/context/PanelContext.tsx
@@ -59,7 +59,7 @@ export function PanelProvider({ children }: PanelProviderProps) {
   ]);
 
   const [collapsedPanels, setCollapsedPanels] = useState<Set<string>>(
-    new Set(),
+    new Set(["codeEditor"]),
   );
 
   // Panel sizes tracking (記錄每個面板的當前尺寸)


### PR DESCRIPTION
# Feature

- Tutorial page implements a 3-stage progressive disclosure state machine (INITIAL → PLAYING → ENDED)
  - INITIAL: CodeEditor is collapsed; ControlBar / StepDescription are hidden; variableStatus tab is disabled.
  - PLAYING: ControlBar appears instantly upon the first operation; 400ms later, CodeEditor automatically expands and switches to the variableStatus tab.
  - ENDED: Automatically switches back to the actionBar tab upon reaching the final frame; variableStatus tab remains enabled, allowing users to manually inspect the final variable snapshot.
- CodeEditor dynamic expansion width: Computes the pixel width of the longest line using Monaco's `getLineLength()` × character width, and clamps the value using `min(maxWidth, contentWidth)` to prevent short code snippets from occupying excessive space.
- FeatureTour navigation compatibility: Temporarily expands CodeEditor when the tour is active (visible during Steps 5/6), and automatically collapses it upon closure if the animation has not yet started.
- Full state machine reset when switching `levelId` (hasStartedAnimation, tab, prevIsAtLastStepRef, CodeEditor collapse).

# Fix
- Fixed an issue where `expand()` triggered a toggle (causing automatic collapse) within the FeatureTour / animation start effects if the Panel was already expanded, resolved by introducing an `isCollapsed()` guard.
- Removed the automatic tab switch back to SmartActionBar after the animation ends
- Fixed an issue where transitioning from ENDED → PLAYING unexpectedly triggered a jump to VariableWatch.